### PR TITLE
Add non-shared scheme as a cause of error 65

### DIFF
--- a/known-xcode-issues.md
+++ b/known-xcode-issues.md
@@ -99,6 +99,7 @@ A quick summary:
   might include additional workarounds / fixes.
 * Try [another Xcode version](http://devcenter.bitrise.io/docs/available-stacks#section-how-to-switch-to-the-new-beta-stacks),
   there are issues which are present in one Xcode version but not in another one.
+* Make sure your desired [Xcode scheme is shared](http://devcenter.bitrise.io/docs/scheme-cannot-be-found). Don't forget to commit and push the changes if you just enabled it.
 * It might also be a [project configuration issue in your Xcode project](https://github.com/bitrise-io/bitrise.io/issues/5#issuecomment-140188658),
   or a [code issue in your tests](https://github.com/bitrise-io/bitrise.io/issues/5#issuecomment-160171566),
   or a [multi threading issue in your code](https://github.com/bitrise-io/bitrise.io/issues/5#issuecomment-190163069).


### PR DESCRIPTION
I recently forgot to mark my desired scheme as shared, thus making `xcodebuild` fail:

```none
xcodebuild: error: The project named "[redacted]" does not contain a scheme named "[redacted]".
The "-list" option can be used to find the names of the schemes in the project.

xcode test exit code: 65
xcode test failed, error: exit status 65
```