### PR TITLE
system_reports/osx-xamarin-stable.log - Android 7.3.1.2 - hotfix

### DIFF
--- a/system_reports/osx-xamarin-stable.log
+++ b/system_reports/osx-xamarin-stable.log
@@ -34,7 +34,7 @@ Java HotSpot(TM) 64-Bit Server VM (build 25.131-b11, mixed mode)
 * tree: tree v1.7.0 (c) 1996 - 2014 by Steve Baker, Thomas Moore, Francesc Rocher, Florian Sesser, Kyosuke Tokoro 
 
 * brew: Homebrew 1.2.1
-Homebrew/homebrew-core (git revision 8270; last commit 2017-05-26)
+Homebrew/homebrew-core (git revision 0fa7e; last commit 2017-05-30)
 ./system_report.sh: line 55: xctool: command not found
 * xctool: 
 * Ansible: ansible 2.3.0.0
@@ -502,14 +502,14 @@ Software:
       User Name: vagrant (vagrant)
       Secure Virtual Memory: Enabled
       System Integrity Protection: Disabled
-      Time since boot: 1 minute
+      Time since boot: 2 minutes
 
 
 ========================================
 
 
 === System infos =======================
-* Free disk space: /dev/disk0s2  199Gi  134Gi   65Gi    68% 2639457 4292327822    0%   /
+* Free disk space: /dev/disk0s2  199Gi  134Gi   65Gi    68% 2640872 4292326407    0%   /
 ========================================
 
 


### PR DESCRIPTION
For some reason Xamarin.Android when called from the terminal does not report the last component of the version number, but this is the Xamarin.Android 7.3.1.2 hotfix, for the Xamarin Stable stack:

https://releases.xamarin.com/stable-release-15-2-2-xamarin-android-xamarin-vs-hotfix/