### PR TITLE
Refreshing the system reports with brew list and brew deps

### DIFF
--- a/system_reports/osx-vs4mac-beta.log
+++ b/system_reports/osx-vs4mac-beta.log
@@ -33,9 +33,9 @@ OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.222-b10, mixed mode)
 * tar: bsdtar 2.8.3 - libarchive 2.8.3
 * tree: tree v1.8.0 (c) 1996 - 2018 by Steve Baker, Thomas Moore, Francesc Rocher, Florian Sesser, Kyosuke Tokoro 
 
-* brew: Homebrew 2.2.0
-Homebrew/homebrew-core (git revision 808d3; last commit 2019-11-28)
-Homebrew/homebrew-cask (git revision e1f2f4; last commit 2019-11-28)
+* brew: Homebrew 2.1.16
+Homebrew/homebrew-core (git revision 079c; last commit 2019-11-21)
+Homebrew/homebrew-cask (git revision 3dd39d; last commit 2019-11-21)
 ./system_report.sh: line 58: xctool: command not found
 * xctool: 
 * Ansible: ansible 2.8.5
@@ -64,6 +64,342 @@ Error: No previously deleted formula found.
 * stepman: 0.11.11
 * envman: 2.2.9
 * cmd-bridge: 0.9.5
+========================================
+
+
+=== Brew list versions ==================
+ansible 2.8.5
+ant 1.10.7
+autoconf 2.69
+carthage 0.33.0
+coreutils 8.31
+flow 0.109.0
+freetype 2.10.1
+gdbm 1.18.1
+gettext 0.20.1
+ghostscript 9.27_1
+git 2.23.0_1
+git-lfs 2.8.0
+glib 2.62.0_1
+go 1.13.1
+gradle 5.6.2
+icu4c 64.2
+ilmbase 2.3.0
+imagemagick 7.0.8-66
+jenv 0.5.2
+jpeg 9c
+libde265 1.0.3
+libffi 3.2.1
+libheif 1.5.1
+libidn2 2.2.0_1
+libomp 9.0.0
+libpng 1.6.37
+libtiff 4.0.10_1
+libtool 2.4.6_1
+libunistring 0.9.10
+libyaml 0.2.2
+little-cms2 2.9
+maven 3.6.2
+mercurial 5.1.1_2
+node 12.11.1
+node@10 10.16.3
+openexr 2.3.0
+openjpeg 2.3.1
+openssl@1.1 1.1.1d
+pcre 8.43
+pcre2 10.33
+pkg-config 0.29.2
+python 3.7.4_1
+python@2 2.7.16_1
+rbenv 1.1.2
+readline 8.0.1
+ruby-build 20191004
+screen 4.6.2
+shared-mime-info 1.14
+sqlite 3.29.0
+tree 1.8.0
+watchman 4.9.0_3
+webp 1.0.3
+wget 1.20.3_1
+x265 3.1.2
+xz 5.2.4
+yarn 1.19.0
+========================================
+
+
+=== Brew deps tree ==================
+ansible
+├── libyaml
+├── openssl@1.1
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+ant
+
+autoconf
+
+carthage
+
+coreutils
+
+flow
+
+freetype
+└── libpng
+
+gdbm
+
+gettext
+
+ghostscript
+└── libtiff
+    └── jpeg
+
+git
+├── gettext
+└── pcre2
+
+git-lfs
+
+glib
+├── gettext
+├── libffi
+├── pcre
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+go
+
+gradle
+
+icu4c
+
+ilmbase
+
+imagemagick
+├── freetype
+│   └── libpng
+├── jpeg
+├── libheif
+│   ├── jpeg
+│   ├── libde265
+│   ├── libpng
+│   ├── shared-mime-info
+│   │   ├── gettext
+│   │   └── glib
+│   │       ├── gettext
+│   │       ├── libffi
+│   │       ├── pcre
+│   │       └── python
+│   │           ├── gdbm
+│   │           ├── openssl@1.1
+│   │           ├── readline
+│   │           ├── sqlite
+│   │           │   └── readline
+│   │           └── xz
+│   └── x265
+├── libomp
+├── libpng
+├── libtiff
+│   └── jpeg
+├── libtool
+├── little-cms2
+│   ├── jpeg
+│   └── libtiff
+│       └── jpeg
+├── openexr
+│   └── ilmbase
+├── openjpeg
+│   ├── libpng
+│   ├── libtiff
+│   │   └── jpeg
+│   └── little-cms2
+│       ├── jpeg
+│       └── libtiff
+│           └── jpeg
+├── webp
+│   ├── jpeg
+│   ├── libpng
+│   └── libtiff
+│       └── jpeg
+└── xz
+
+jenv
+
+jpeg
+
+libde265
+
+libffi
+
+libheif
+├── jpeg
+├── libde265
+├── libpng
+├── shared-mime-info
+│   ├── gettext
+│   └── glib
+│       ├── gettext
+│       ├── libffi
+│       ├── pcre
+│       └── python
+│           ├── gdbm
+│           ├── openssl@1.1
+│           ├── readline
+│           ├── sqlite
+│           │   └── readline
+│           └── xz
+└── x265
+
+libidn2
+├── gettext
+└── libunistring
+
+libomp
+
+libpng
+
+libtiff
+└── jpeg
+
+libtool
+
+libunistring
+
+libyaml
+
+little-cms2
+├── jpeg
+└── libtiff
+    └── jpeg
+
+maven
+
+mercurial
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+node
+└── icu4c
+
+node@10
+└── icu4c
+
+openexr
+└── ilmbase
+
+openjpeg
+├── libpng
+├── libtiff
+│   └── jpeg
+└── little-cms2
+    ├── jpeg
+    └── libtiff
+        └── jpeg
+
+openssl@1.1
+
+pcre
+
+pcre2
+
+pkg-config
+
+python
+├── gdbm
+├── openssl@1.1
+├── readline
+├── sqlite
+│   └── readline
+└── xz
+
+python@2
+├── gdbm
+├── openssl@1.1
+├── readline
+└── sqlite
+    └── readline
+
+rbenv
+└── ruby-build
+    ├── autoconf
+    ├── pkg-config
+    └── readline
+
+readline
+
+ruby-build
+├── autoconf
+├── pkg-config
+└── readline
+
+screen
+
+shared-mime-info
+├── gettext
+└── glib
+    ├── gettext
+    ├── libffi
+    ├── pcre
+    └── python
+        ├── gdbm
+        ├── openssl@1.1
+        ├── readline
+        ├── sqlite
+        │   └── readline
+        └── xz
+
+sqlite
+└── readline
+
+tree
+
+watchman
+├── openssl@1.1
+├── pcre
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+webp
+├── jpeg
+├── libpng
+└── libtiff
+    └── jpeg
+
+wget
+├── libidn2
+│   ├── gettext
+│   └── libunistring
+└── openssl@1.1
+
+x265
+
+xz
+
+yarn
+└── node
+    └── icu4c
+
 ========================================
 
 
@@ -742,18 +1078,18 @@ Software:
       Kernel Version: Darwin 18.7.0
       Boot Volume: Untitled
       Boot Mode: Normal
-      Computer Name: stg-vs4mac-beta-191128163145-nm4z9seC3gjzCNjdoMpkUQ
+      Computer Name: prd-std-b-vs4mac-beta-191204104746-7JvYiXCvkLWuBEGeu3Wqzh
       User Name: vagrant (vagrant)
       Secure Virtual Memory: Enabled
       System Integrity Protection: Disabled
-      Time since boot: 24 minutes
+      Time since boot: 9 minutes
 
 
 ========================================
 
 
 === System infos =======================
-* Free disk space: /dev/disk1s1  200Gi  168Gi   31Gi    85% 4738251 9223372036850037556    0%   /
+* Free disk space: /dev/disk1s1  200Gi  169Gi   30Gi    85% 4733914 9223372036850041893    0%   /
 ========================================
 
 
@@ -786,7 +1122,7 @@ Copyright (C) 2002-2014 Novell, Inc, Xamarin Inc and Contributors. www.mono-proj
 cat: /Developer/MonoAndroid/usr/Version: No such file or directory
 
 * Xamarin.iOS
-./system_report.sh: line 203: /Developer/MonoTouch/usr/bin/mtouch: No such file or directory
+./system_report.sh: line 215: /Developer/MonoTouch/usr/bin/mtouch: No such file or directory
 
 * debug.keystore path:
 /Users/vagrant/.local/share/Xamarin/Mono for Android/debug.keystore

--- a/system_reports/osx-vs4mac-previous-stable.log
+++ b/system_reports/osx-vs4mac-previous-stable.log
@@ -33,9 +33,9 @@ OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.232-b09, mixed mode)
 * tar: bsdtar 2.8.3 - libarchive 2.8.3
 * tree: tree v1.8.0 (c) 1996 - 2018 by Steve Baker, Thomas Moore, Francesc Rocher, Florian Sesser, Kyosuke Tokoro 
 
-* brew: Homebrew 2.2.0
-Homebrew/homebrew-core (git revision c2ba6; last commit 2019-11-27)
-Homebrew/homebrew-cask (git revision 60b11; last commit 2019-11-28)
+* brew: Homebrew 2.1.16
+Homebrew/homebrew-core (git revision 079ce5; last commit 2019-11-21)
+Homebrew/homebrew-cask (git revision b6142; last commit 2019-11-21)
 ./system_report.sh: line 58: xctool: command not found
 * xctool: 
 * Ansible: ansible 2.7.9
@@ -45,7 +45,6 @@ Homebrew/homebrew-cask (git revision 60b11; last commit 2019-11-28)
 * gtimeout: timeout (GNU coreutils) 8.31
 * watchman: 4.9.0
 * flow: Flow, a static type checker for JavaScript, version 0.95.2
-Please update to the latest Carthage version: 0.34.0. You currently are on 0.33.0
 * carthage: 0.33.0
 * imagemagick (convert): Version: ImageMagick 7.0.8-35 Q16 x86_64 2019-03-25 https://imagemagick.org
 * ghostscript (ps2ascii): 9.26
@@ -65,6 +64,333 @@ Error: No previously deleted formula found.
 * stepman: 0.11.11
 * envman: 2.2.9
 * cmd-bridge: 0.9.5
+========================================
+
+
+=== Brew list versions ==================
+ansible 2.7.9
+autoconf 2.69
+carthage 0.33.0
+coreutils 8.31
+flow 0.95.2
+freetype 2.10.0
+gdbm 1.18.1
+gettext 0.19.8.1
+ghostscript 9.26_1
+git 2.21.0
+git-lfs 2.7.1
+glib 2.60.0_1
+go 1.12.1
+icu4c 63.1
+ilmbase 2.2.1
+imagemagick 7.0.8-35
+jenv 0.5.2
+jpeg 9c
+libde265 1.0.3
+libffi 3.2.1
+libheif 1.4.0
+libidn2 2.1.1a
+libomp 7.0.0
+libpng 1.6.36
+libtiff 4.0.10_1
+libtool 2.4.6_1
+libunistring 0.9.10
+libyaml 0.2.2
+little-cms2 2.9
+mercurial 4.9.1
+node 11.12.0
+node@10 10.15.2
+openexr 2.2.0_1
+openjpeg 2.3.0
+openssl 1.0.2r
+pcre 8.43
+pcre2 10.32
+pkg-config 0.29.2
+python 3.7.2_2
+python@2 2.7.16
+rbenv 1.1.2
+readline 8.0.0
+ruby-build 20190320
+screen 4.6.2
+shared-mime-info 1.12
+sqlite 3.27.2
+tree 1.8.0
+watchman 4.9.0_2
+webp 1.0.2
+wget 1.20.1_4
+x265 3.0
+xz 5.2.4
+yarn 1.15.2
+========================================
+
+
+=== Brew deps tree ==================
+ansible
+├── libyaml
+├── openssl@1.1
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+autoconf
+
+carthage
+
+coreutils
+
+flow
+
+freetype
+└── libpng
+
+gdbm
+
+gettext
+
+ghostscript
+└── libtiff
+    └── jpeg
+
+git
+├── gettext
+└── pcre2
+
+git-lfs
+
+glib
+├── gettext
+├── libffi
+├── pcre
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+go
+
+icu4c
+
+ilmbase
+
+imagemagick
+├── freetype
+│   └── libpng
+├── jpeg
+├── libheif
+│   ├── jpeg
+│   ├── libde265
+│   ├── libpng
+│   ├── shared-mime-info
+│   │   ├── gettext
+│   │   └── glib
+│   │       ├── gettext
+│   │       ├── libffi
+│   │       ├── pcre
+│   │       └── python
+│   │           ├── gdbm
+│   │           ├── openssl@1.1
+│   │           ├── readline
+│   │           ├── sqlite
+│   │           │   └── readline
+│   │           └── xz
+│   └── x265
+├── libomp
+├── libpng
+├── libtiff
+│   └── jpeg
+├── libtool
+├── little-cms2
+│   ├── jpeg
+│   └── libtiff
+│       └── jpeg
+├── openexr
+│   └── ilmbase
+├── openjpeg
+│   ├── libpng
+│   ├── libtiff
+│   │   └── jpeg
+│   └── little-cms2
+│       ├── jpeg
+│       └── libtiff
+│           └── jpeg
+├── webp
+│   ├── jpeg
+│   ├── libpng
+│   └── libtiff
+│       └── jpeg
+└── xz
+
+jenv
+
+jpeg
+
+libde265
+
+libffi
+
+libheif
+├── jpeg
+├── libde265
+├── libpng
+├── shared-mime-info
+│   ├── gettext
+│   └── glib
+│       ├── gettext
+│       ├── libffi
+│       ├── pcre
+│       └── python
+│           ├── gdbm
+│           ├── openssl@1.1
+│           ├── readline
+│           ├── sqlite
+│           │   └── readline
+│           └── xz
+└── x265
+
+libidn2
+├── gettext
+└── libunistring
+
+libomp
+
+libpng
+
+libtiff
+└── jpeg
+
+libtool
+
+libunistring
+
+libyaml
+
+little-cms2
+├── jpeg
+└── libtiff
+    └── jpeg
+
+mercurial
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+node
+└── icu4c
+
+node@10
+└── icu4c
+
+openexr
+└── ilmbase
+
+openjpeg
+├── libpng
+├── libtiff
+│   └── jpeg
+└── little-cms2
+    ├── jpeg
+    └── libtiff
+        └── jpeg
+
+openssl
+
+pcre
+
+pcre2
+
+pkg-config
+
+python
+├── gdbm
+├── openssl@1.1
+├── readline
+├── sqlite
+│   └── readline
+└── xz
+
+python@2
+├── gdbm
+├── openssl@1.1
+├── readline
+└── sqlite
+    └── readline
+
+rbenv
+└── ruby-build
+    ├── autoconf
+    ├── pkg-config
+    └── readline
+
+readline
+
+ruby-build
+├── autoconf
+├── pkg-config
+└── readline
+
+screen
+
+shared-mime-info
+├── gettext
+└── glib
+    ├── gettext
+    ├── libffi
+    ├── pcre
+    └── python
+        ├── gdbm
+        ├── openssl@1.1
+        ├── readline
+        ├── sqlite
+        │   └── readline
+        └── xz
+
+sqlite
+└── readline
+
+tree
+
+watchman
+├── openssl@1.1
+├── pcre
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+webp
+├── jpeg
+├── libpng
+└── libtiff
+    └── jpeg
+
+wget
+├── libidn2
+│   ├── gettext
+│   └── libunistring
+└── openssl@1.1
+
+x265
+
+xz
+
+yarn
+└── node
+    └── icu4c
+
 ========================================
 
 
@@ -712,18 +1038,18 @@ Software:
       Kernel Version: Darwin 18.5.0
       Boot Volume: Untitled
       Boot Mode: Normal
-      Computer Name: stg-vs4mac-stable-previous-191128163145-DNrhpFTtJSym2Tvhjf7YxS
+      Computer Name: prd-std-y-vs4mac-stable-previous-191204101511-8JggrshD7xnZAeqjGoEbTK
       User Name: vagrant (vagrant)
       Secure Virtual Memory: Enabled
       System Integrity Protection: Disabled
-      Time since boot: 22 minutes
+      Time since boot: 42 minutes
 
 
 ========================================
 
 
 === System infos =======================
-* Free disk space: /dev/disk1s1  200Gi  150Gi   50Gi    76% 4468198 9223372036850307609    0%   /
+* Free disk space: /dev/disk1s1  200Gi  150Gi   50Gi    76% 4464068 9223372036850311739    0%   /
 ========================================
 
 

--- a/system_reports/osx-vs4mac-stable.log
+++ b/system_reports/osx-vs4mac-stable.log
@@ -33,9 +33,9 @@ OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.222-b10, mixed mode)
 * tar: bsdtar 2.8.3 - libarchive 2.8.3
 * tree: tree v1.8.0 (c) 1996 - 2018 by Steve Baker, Thomas Moore, Francesc Rocher, Florian Sesser, Kyosuke Tokoro 
 
-* brew: Homebrew 2.2.0
-Homebrew/homebrew-core (git revision 808d3; last commit 2019-11-28)
-Homebrew/homebrew-cask (git revision b8426; last commit 2019-11-28)
+* brew: Homebrew 2.1.16
+Homebrew/homebrew-core (git revision 079c; last commit 2019-11-21)
+Homebrew/homebrew-cask (git revision 3dd39d; last commit 2019-11-21)
 ./system_report.sh: line 58: xctool: command not found
 * xctool: 
 * Ansible: ansible 2.8.5
@@ -45,7 +45,6 @@ Homebrew/homebrew-cask (git revision b8426; last commit 2019-11-28)
 * gtimeout: timeout (GNU coreutils) 8.31
 * watchman: 4.9.0
 * flow: Flow, a static type checker for JavaScript, version 0.109.0
-Please update to the latest Carthage version: 0.34.0. You currently are on 0.33.0
 * carthage: 0.33.0
 * imagemagick (convert): Version: ImageMagick 7.0.8-66 Q16 x86_64 2019-09-23 https://imagemagick.org
 * ghostscript (ps2ascii): 9.27
@@ -65,6 +64,342 @@ Error: No previously deleted formula found.
 * stepman: 0.11.11
 * envman: 2.2.9
 * cmd-bridge: 0.9.5
+========================================
+
+
+=== Brew list versions ==================
+ansible 2.8.5
+ant 1.10.7
+autoconf 2.69
+carthage 0.33.0
+coreutils 8.31
+flow 0.109.0
+freetype 2.10.1
+gdbm 1.18.1
+gettext 0.20.1
+ghostscript 9.27_1
+git 2.23.0_1
+git-lfs 2.8.0
+glib 2.62.0_1
+go 1.13.1
+gradle 5.6.2
+icu4c 64.2
+ilmbase 2.3.0
+imagemagick 7.0.8-66
+jenv 0.5.2
+jpeg 9c
+libde265 1.0.3
+libffi 3.2.1
+libheif 1.5.1
+libidn2 2.2.0_1
+libomp 9.0.0
+libpng 1.6.37
+libtiff 4.0.10_1
+libtool 2.4.6_1
+libunistring 0.9.10
+libyaml 0.2.2
+little-cms2 2.9
+maven 3.6.2
+mercurial 5.1.1_2
+node 12.11.1
+node@10 10.16.3
+openexr 2.3.0
+openjpeg 2.3.1
+openssl@1.1 1.1.1d
+pcre 8.43
+pcre2 10.33
+pkg-config 0.29.2
+python 3.7.4_1
+python@2 2.7.16_1
+rbenv 1.1.2
+readline 8.0.1
+ruby-build 20191004
+screen 4.6.2
+shared-mime-info 1.14
+sqlite 3.29.0
+tree 1.8.0
+watchman 4.9.0_3
+webp 1.0.3
+wget 1.20.3_1
+x265 3.1.2
+xz 5.2.4
+yarn 1.19.0
+========================================
+
+
+=== Brew deps tree ==================
+ansible
+├── libyaml
+├── openssl@1.1
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+ant
+
+autoconf
+
+carthage
+
+coreutils
+
+flow
+
+freetype
+└── libpng
+
+gdbm
+
+gettext
+
+ghostscript
+└── libtiff
+    └── jpeg
+
+git
+├── gettext
+└── pcre2
+
+git-lfs
+
+glib
+├── gettext
+├── libffi
+├── pcre
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+go
+
+gradle
+
+icu4c
+
+ilmbase
+
+imagemagick
+├── freetype
+│   └── libpng
+├── jpeg
+├── libheif
+│   ├── jpeg
+│   ├── libde265
+│   ├── libpng
+│   ├── shared-mime-info
+│   │   ├── gettext
+│   │   └── glib
+│   │       ├── gettext
+│   │       ├── libffi
+│   │       ├── pcre
+│   │       └── python
+│   │           ├── gdbm
+│   │           ├── openssl@1.1
+│   │           ├── readline
+│   │           ├── sqlite
+│   │           │   └── readline
+│   │           └── xz
+│   └── x265
+├── libomp
+├── libpng
+├── libtiff
+│   └── jpeg
+├── libtool
+├── little-cms2
+│   ├── jpeg
+│   └── libtiff
+│       └── jpeg
+├── openexr
+│   └── ilmbase
+├── openjpeg
+│   ├── libpng
+│   ├── libtiff
+│   │   └── jpeg
+│   └── little-cms2
+│       ├── jpeg
+│       └── libtiff
+│           └── jpeg
+├── webp
+│   ├── jpeg
+│   ├── libpng
+│   └── libtiff
+│       └── jpeg
+└── xz
+
+jenv
+
+jpeg
+
+libde265
+
+libffi
+
+libheif
+├── jpeg
+├── libde265
+├── libpng
+├── shared-mime-info
+│   ├── gettext
+│   └── glib
+│       ├── gettext
+│       ├── libffi
+│       ├── pcre
+│       └── python
+│           ├── gdbm
+│           ├── openssl@1.1
+│           ├── readline
+│           ├── sqlite
+│           │   └── readline
+│           └── xz
+└── x265
+
+libidn2
+├── gettext
+└── libunistring
+
+libomp
+
+libpng
+
+libtiff
+└── jpeg
+
+libtool
+
+libunistring
+
+libyaml
+
+little-cms2
+├── jpeg
+└── libtiff
+    └── jpeg
+
+maven
+
+mercurial
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+node
+└── icu4c
+
+node@10
+└── icu4c
+
+openexr
+└── ilmbase
+
+openjpeg
+├── libpng
+├── libtiff
+│   └── jpeg
+└── little-cms2
+    ├── jpeg
+    └── libtiff
+        └── jpeg
+
+openssl@1.1
+
+pcre
+
+pcre2
+
+pkg-config
+
+python
+├── gdbm
+├── openssl@1.1
+├── readline
+├── sqlite
+│   └── readline
+└── xz
+
+python@2
+├── gdbm
+├── openssl@1.1
+├── readline
+└── sqlite
+    └── readline
+
+rbenv
+└── ruby-build
+    ├── autoconf
+    ├── pkg-config
+    └── readline
+
+readline
+
+ruby-build
+├── autoconf
+├── pkg-config
+└── readline
+
+screen
+
+shared-mime-info
+├── gettext
+└── glib
+    ├── gettext
+    ├── libffi
+    ├── pcre
+    └── python
+        ├── gdbm
+        ├── openssl@1.1
+        ├── readline
+        ├── sqlite
+        │   └── readline
+        └── xz
+
+sqlite
+└── readline
+
+tree
+
+watchman
+├── openssl@1.1
+├── pcre
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+webp
+├── jpeg
+├── libpng
+└── libtiff
+    └── jpeg
+
+wget
+├── libidn2
+│   ├── gettext
+│   └── libunistring
+└── openssl@1.1
+
+x265
+
+xz
+
+yarn
+└── node
+    └── icu4c
+
 ========================================
 
 
@@ -743,18 +1078,18 @@ Software:
       Kernel Version: Darwin 18.7.0
       Boot Volume: Untitled
       Boot Mode: Normal
-      Computer Name: stg-vs4mac-stable-191128163600-YEiEqEDCHgFZFFA6o9KvTD
+      Computer Name: prd-std-y-vs4mac-stable-191204105431-wK7Q6vtikQXBDRsEjnLG63
       User Name: vagrant (vagrant)
       Secure Virtual Memory: Enabled
       System Integrity Protection: Disabled
-      Time since boot: 19 minutes
+      Time since boot: 3 minutes
 
 
 ========================================
 
 
 === System infos =======================
-* Free disk space: /dev/disk1s1  200Gi  167Gi   32Gi    84% 4733702 9223372036850042105    0%   /
+* Free disk space: /dev/disk1s1  200Gi  166Gi   33Gi    84% 4729729 9223372036850046078    0%   /
 ========================================
 
 
@@ -763,9 +1098,9 @@ Software:
 --- Xamarin
 
 * Visual Studio
-Release ID: 803100002
-Git revision: add3a4998a5cb5b081e0404e1fe13acfecb7801d
-Build date: 2019-11-20 13:35:15+00
+Release ID: 803090002
+Git revision: 83e2adea93475846201094761baae3414da20b4e
+Build date: 2019-11-14 15:17:12+00
 Build branch: release-8.3
 * Mono version:
 Mono JIT compiler version 6.4.0.208 (2019-06/07c23f2ca43 Wed Oct  2 04:52:23 EDT 2019)
@@ -787,7 +1122,7 @@ Copyright (C) 2002-2014 Novell, Inc, Xamarin Inc and Contributors. www.mono-proj
 cat: /Developer/MonoAndroid/usr/Version: No such file or directory
 
 * Xamarin.iOS
-./system_report.sh: line 203: /Developer/MonoTouch/usr/bin/mtouch: No such file or directory
+./system_report.sh: line 215: /Developer/MonoTouch/usr/bin/mtouch: No such file or directory
 
 * debug.keystore path:
 /Users/vagrant/.local/share/Xamarin/Mono for Android/debug.keystore

--- a/system_reports/osx-xcode-10.0.x.log
+++ b/system_reports/osx-xcode-10.0.x.log
@@ -33,9 +33,9 @@ OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.232-b09, mixed mode)
 * tar: bsdtar 2.8.3 - libarchive 2.8.3
 * tree: tree v1.7.0 (c) 1996 - 2014 by Steve Baker, Thomas Moore, Francesc Rocher, Florian Sesser, Kyosuke Tokoro 
 
-* brew: Homebrew 2.2.0
-Homebrew/homebrew-core (git revision c2ba6; last commit 2019-11-27)
-Homebrew/homebrew-cask (git revision 60b11; last commit 2019-11-28)
+* brew: Homebrew 2.1.16
+Homebrew/homebrew-core (git revision 079ce5; last commit 2019-11-21)
+Homebrew/homebrew-cask (git revision b6142; last commit 2019-11-21)
 ./system_report.sh: line 58: xctool: command not found
 * xctool: 
 * Ansible: ansible 2.6.4
@@ -64,6 +64,236 @@ Error: No previously deleted formula found.
 * stepman: 0.11.11
 * envman: 2.2.9
 * cmd-bridge: 0.9.5
+========================================
+
+
+=== Brew list versions ==================
+ansible 2.6.4
+ant 1.10.7
+carthage 0.33.0
+coreutils 8.30
+flow 0.81.0
+freetype 2.9.1
+gdbm 1.18
+gettext 0.19.8.1
+ghostscript 9.25
+git 2.19.0_1
+git-lfs 2.5.2
+go 1.11
+gradle 6.0.1
+icu4c 62.1
+imagemagick 7.0.8-11_2
+jenv 0.5.2
+jpeg 9c
+libidn2 2.0.5
+libpng 1.6.35
+libtiff 4.0.9_4
+libtool 2.4.6_1
+libunistring 0.9.10
+libyaml 0.2.1
+little-cms2 2.9
+maven 3.6.2
+mercurial 4.7.1
+node 10.10.0
+node@8 8.12.0
+openssl 1.0.2p
+pcre 8.42
+pcre2 10.32
+python@2 2.7.15_1
+readline 7.0.5
+ruby 2.5.1
+screen 4.6.2
+sqlite 3.25.1
+tree 1.7.0
+watchman 4.9.0
+wget 1.19.5
+xz 5.2.4
+yarn 1.9.4
+========================================
+
+
+=== Brew deps tree ==================
+ansible
+├── libyaml
+├── openssl@1.1
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+ant
+
+carthage
+
+coreutils
+
+flow
+
+freetype
+└── libpng
+
+gdbm
+
+gettext
+
+ghostscript
+└── libtiff
+    └── jpeg
+
+git
+├── gettext
+└── pcre2
+
+git-lfs
+
+go
+
+gradle
+
+icu4c
+
+imagemagick
+├── freetype
+│   └── libpng
+├── jpeg
+├── libheif
+│   ├── jpeg
+│   ├── libde265
+│   ├── libpng
+│   ├── shared-mime-info
+│   │   ├── gettext
+│   │   └── glib
+│   │       ├── gettext
+│   │       ├── libffi
+│   │       ├── pcre
+│   │       └── python
+│   │           ├── gdbm
+│   │           ├── openssl@1.1
+│   │           ├── readline
+│   │           ├── sqlite
+│   │           │   └── readline
+│   │           └── xz
+│   └── x265
+├── libomp
+├── libpng
+├── libtiff
+│   └── jpeg
+├── libtool
+├── little-cms2
+│   ├── jpeg
+│   └── libtiff
+│       └── jpeg
+├── openexr
+│   └── ilmbase
+├── openjpeg
+│   ├── libpng
+│   ├── libtiff
+│   │   └── jpeg
+│   └── little-cms2
+│       ├── jpeg
+│       └── libtiff
+│           └── jpeg
+├── webp
+│   ├── jpeg
+│   ├── libpng
+│   └── libtiff
+│       └── jpeg
+└── xz
+
+jenv
+
+jpeg
+
+libidn2
+├── gettext
+└── libunistring
+
+libpng
+
+libtiff
+└── jpeg
+
+libtool
+
+libunistring
+
+libyaml
+
+little-cms2
+├── jpeg
+└── libtiff
+    └── jpeg
+
+maven
+
+mercurial
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+node
+└── icu4c
+
+node@8
+└── icu4c
+
+openssl
+
+pcre
+
+pcre2
+
+python@2
+├── gdbm
+├── openssl@1.1
+├── readline
+└── sqlite
+    └── readline
+
+readline
+
+ruby
+├── libyaml
+├── openssl@1.1
+└── readline
+
+screen
+
+sqlite
+└── readline
+
+tree
+
+watchman
+├── openssl@1.1
+├── pcre
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+wget
+├── libidn2
+│   ├── gettext
+│   └── libunistring
+└── openssl@1.1
+
+xz
+
+yarn
+└── node
+    └── icu4c
+
 ========================================
 
 
@@ -621,18 +851,18 @@ Software:
       Kernel Version: Darwin 17.7.0
       Boot Volume: Macintosh HD
       Boot Mode: Normal
-      Computer Name: stg-xcode-10-191128163820-AnjAoh3tifUKkTfrp8cqvh
+      Computer Name: prd-std-g-xcode-10-191204104043-UuNPX3oB6ErnR6qztNWxyH
       User Name: vagrant (vagrant)
       Secure Virtual Memory: Enabled
       System Integrity Protection: Disabled
-      Time since boot: 12 minutes
+      Time since boot: 18 minutes
 
 
 ========================================
 
 
 === System infos =======================
-* Free disk space: /dev/disk0s2  199Gi  123Gi   76Gi    62% 3827738 4291139541    0%   /
+* Free disk space: /dev/disk0s2  199Gi  123Gi   76Gi    62% 3823716 4291143563    0%   /
 ========================================
 
 --- Android

--- a/system_reports/osx-xcode-10.1.x.log
+++ b/system_reports/osx-xcode-10.1.x.log
@@ -33,9 +33,9 @@ OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.232-b09, mixed mode)
 * tar: bsdtar 2.8.3 - libarchive 2.8.3
 * tree: tree v1.7.0 (c) 1996 - 2014 by Steve Baker, Thomas Moore, Francesc Rocher, Florian Sesser, Kyosuke Tokoro 
 
-* brew: Homebrew 2.2.0
-Homebrew/homebrew-core (git revision c2ba6; last commit 2019-11-27)
-Homebrew/homebrew-cask (git revision 60b11; last commit 2019-11-28)
+* brew: Homebrew 2.1.16
+Homebrew/homebrew-core (git revision 079ce5; last commit 2019-11-21)
+Homebrew/homebrew-cask (git revision b6142; last commit 2019-11-21)
 ./system_report.sh: line 58: xctool: command not found
 * xctool: 
 * Ansible: ansible 2.7.1
@@ -64,6 +64,262 @@ Error: No previously deleted formula found.
 * stepman: 0.11.11
 * envman: 2.2.9
 * cmd-bridge: 0.9.5
+========================================
+
+
+=== Brew list versions ==================
+ansible 2.7.1
+ant 1.10.7
+carthage 0.33.0
+coreutils 8.30
+flow 0.81.0
+freetype 2.9.1
+gdbm 1.18.1
+gettext 0.19.8.1
+ghostscript 9.25
+git 2.19.1
+git-lfs 2.5.2
+go 1.11.1
+gradle 6.0.1
+icu4c 62.1
+imagemagick 7.0.8-14
+jenv 0.5.2
+jpeg 9c
+libidn2 2.0.5
+libpng 1.6.35
+libtiff 4.0.9_4
+libtool 2.4.6_1
+libunistring 0.9.10
+libyaml 0.2.1
+little-cms2 2.9
+maven 3.6.2
+mercurial 4.7.2
+node 11.0.0
+node@8 8.12.0
+openjpeg 2.3.0
+openssl 1.0.2p
+pcre 8.42
+pcre2 10.32
+python 3.7.0
+python@2 2.7.15_1
+readline 7.0.5
+ruby 2.5.3
+screen 4.6.2
+sqlite 3.25.2
+tree 1.7.0
+watchman 4.9.0_2
+webp 1.0.0
+wget 1.19.5
+xz 5.2.4
+yarn 1.12.1
+========================================
+
+
+=== Brew deps tree ==================
+ansible
+├── libyaml
+├── openssl@1.1
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+ant
+
+carthage
+
+coreutils
+
+flow
+
+freetype
+└── libpng
+
+gdbm
+
+gettext
+
+ghostscript
+└── libtiff
+    └── jpeg
+
+git
+├── gettext
+└── pcre2
+
+git-lfs
+
+go
+
+gradle
+
+icu4c
+
+imagemagick
+├── freetype
+│   └── libpng
+├── jpeg
+├── libheif
+│   ├── jpeg
+│   ├── libde265
+│   ├── libpng
+│   ├── shared-mime-info
+│   │   ├── gettext
+│   │   └── glib
+│   │       ├── gettext
+│   │       ├── libffi
+│   │       ├── pcre
+│   │       └── python
+│   │           ├── gdbm
+│   │           ├── openssl@1.1
+│   │           ├── readline
+│   │           ├── sqlite
+│   │           │   └── readline
+│   │           └── xz
+│   └── x265
+├── libomp
+├── libpng
+├── libtiff
+│   └── jpeg
+├── libtool
+├── little-cms2
+│   ├── jpeg
+│   └── libtiff
+│       └── jpeg
+├── openexr
+│   └── ilmbase
+├── openjpeg
+│   ├── libpng
+│   ├── libtiff
+│   │   └── jpeg
+│   └── little-cms2
+│       ├── jpeg
+│       └── libtiff
+│           └── jpeg
+├── webp
+│   ├── jpeg
+│   ├── libpng
+│   └── libtiff
+│       └── jpeg
+└── xz
+
+jenv
+
+jpeg
+
+libidn2
+├── gettext
+└── libunistring
+
+libpng
+
+libtiff
+└── jpeg
+
+libtool
+
+libunistring
+
+libyaml
+
+little-cms2
+├── jpeg
+└── libtiff
+    └── jpeg
+
+maven
+
+mercurial
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+node
+└── icu4c
+
+node@8
+└── icu4c
+
+openjpeg
+├── libpng
+├── libtiff
+│   └── jpeg
+└── little-cms2
+    ├── jpeg
+    └── libtiff
+        └── jpeg
+
+openssl
+
+pcre
+
+pcre2
+
+python
+├── gdbm
+├── openssl@1.1
+├── readline
+├── sqlite
+│   └── readline
+└── xz
+
+python@2
+├── gdbm
+├── openssl@1.1
+├── readline
+└── sqlite
+    └── readline
+
+readline
+
+ruby
+├── libyaml
+├── openssl@1.1
+└── readline
+
+screen
+
+sqlite
+└── readline
+
+tree
+
+watchman
+├── openssl@1.1
+├── pcre
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+webp
+├── jpeg
+├── libpng
+└── libtiff
+    └── jpeg
+
+wget
+├── libidn2
+│   ├── gettext
+│   └── libunistring
+└── openssl@1.1
+
+xz
+
+yarn
+└── node
+    └── icu4c
+
 ========================================
 
 
@@ -658,18 +914,18 @@ Software:
       Kernel Version: Darwin 17.7.0
       Boot Volume: Macintosh HD
       Boot Mode: Normal
-      Computer Name: stg-xcode-10-1-191128162417-wHseepTKZ5RxNEK2dPSYg5
+      Computer Name: prd-std-y-xcode-10-1-191204104753-WwjnUfgicdukm2JRJ9soEJ
       User Name: vagrant (vagrant)
       Secure Virtual Memory: Enabled
       System Integrity Protection: Disabled
-      Time since boot: 24 minutes
+      Time since boot: 9 minutes
 
 
 ========================================
 
 
 === System infos =======================
-* Free disk space: /dev/disk0s2  199Gi  135Gi   64Gi    68% 4122896 4290844383    0%   /
+* Free disk space: /dev/disk0s2  199Gi  135Gi   64Gi    68% 4118856 4290848423    0%   /
 ========================================
 
 --- Android

--- a/system_reports/osx-xcode-10.2.x.log
+++ b/system_reports/osx-xcode-10.2.x.log
@@ -33,9 +33,9 @@ OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.232-b09, mixed mode)
 * tar: bsdtar 2.8.3 - libarchive 2.8.3
 * tree: tree v1.8.0 (c) 1996 - 2018 by Steve Baker, Thomas Moore, Francesc Rocher, Florian Sesser, Kyosuke Tokoro 
 
-* brew: Homebrew 2.2.0
-Homebrew/homebrew-core (git revision c2ba6; last commit 2019-11-27)
-Homebrew/homebrew-cask (git revision 60b11; last commit 2019-11-28)
+* brew: Homebrew 2.1.16
+Homebrew/homebrew-core (git revision 079ce5; last commit 2019-11-21)
+Homebrew/homebrew-cask (git revision b6142; last commit 2019-11-21)
 ./system_report.sh: line 58: xctool: command not found
 * xctool: 
 * Ansible: ansible 2.7.9
@@ -64,6 +64,342 @@ Error: No previously deleted formula found.
 * stepman: 0.11.11
 * envman: 2.2.9
 * cmd-bridge: 0.9.5
+========================================
+
+
+=== Brew list versions ==================
+ansible 2.7.9
+ant 1.10.7
+autoconf 2.69
+carthage 0.33.0
+coreutils 8.31
+flow 0.95.2
+freetype 2.10.0
+gdbm 1.18.1
+gettext 0.19.8.1
+ghostscript 9.26_1
+git 2.21.0
+git-lfs 2.7.1
+glib 2.60.0_1
+go 1.12.1
+gradle 6.0.1
+icu4c 63.1
+ilmbase 2.2.1
+imagemagick 7.0.8-35
+jenv 0.5.2
+jpeg 9c
+libde265 1.0.3
+libffi 3.2.1
+libheif 1.4.0
+libidn2 2.1.1a
+libomp 7.0.0
+libpng 1.6.36
+libtiff 4.0.10_1
+libtool 2.4.6_1
+libunistring 0.9.10
+libyaml 0.2.2
+little-cms2 2.9
+maven 3.6.2
+mercurial 4.9.1
+node 11.12.0
+node@10 10.15.2
+openexr 2.2.0_1
+openjpeg 2.3.0
+openssl 1.0.2r
+pcre 8.43
+pcre2 10.32
+pkg-config 0.29.2
+python 3.7.2_2
+python@2 2.7.16
+rbenv 1.1.2
+readline 8.0.0
+ruby-build 20190320
+screen 4.6.2
+shared-mime-info 1.12
+sqlite 3.27.2
+tree 1.8.0
+watchman 4.9.0_2
+webp 1.0.2
+wget 1.20.1_4
+x265 3.0
+xz 5.2.4
+yarn 1.15.2
+========================================
+
+
+=== Brew deps tree ==================
+ansible
+├── libyaml
+├── openssl@1.1
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+ant
+
+autoconf
+
+carthage
+
+coreutils
+
+flow
+
+freetype
+└── libpng
+
+gdbm
+
+gettext
+
+ghostscript
+└── libtiff
+    └── jpeg
+
+git
+├── gettext
+└── pcre2
+
+git-lfs
+
+glib
+├── gettext
+├── libffi
+├── pcre
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+go
+
+gradle
+
+icu4c
+
+ilmbase
+
+imagemagick
+├── freetype
+│   └── libpng
+├── jpeg
+├── libheif
+│   ├── jpeg
+│   ├── libde265
+│   ├── libpng
+│   ├── shared-mime-info
+│   │   ├── gettext
+│   │   └── glib
+│   │       ├── gettext
+│   │       ├── libffi
+│   │       ├── pcre
+│   │       └── python
+│   │           ├── gdbm
+│   │           ├── openssl@1.1
+│   │           ├── readline
+│   │           ├── sqlite
+│   │           │   └── readline
+│   │           └── xz
+│   └── x265
+├── libomp
+├── libpng
+├── libtiff
+│   └── jpeg
+├── libtool
+├── little-cms2
+│   ├── jpeg
+│   └── libtiff
+│       └── jpeg
+├── openexr
+│   └── ilmbase
+├── openjpeg
+│   ├── libpng
+│   ├── libtiff
+│   │   └── jpeg
+│   └── little-cms2
+│       ├── jpeg
+│       └── libtiff
+│           └── jpeg
+├── webp
+│   ├── jpeg
+│   ├── libpng
+│   └── libtiff
+│       └── jpeg
+└── xz
+
+jenv
+
+jpeg
+
+libde265
+
+libffi
+
+libheif
+├── jpeg
+├── libde265
+├── libpng
+├── shared-mime-info
+│   ├── gettext
+│   └── glib
+│       ├── gettext
+│       ├── libffi
+│       ├── pcre
+│       └── python
+│           ├── gdbm
+│           ├── openssl@1.1
+│           ├── readline
+│           ├── sqlite
+│           │   └── readline
+│           └── xz
+└── x265
+
+libidn2
+├── gettext
+└── libunistring
+
+libomp
+
+libpng
+
+libtiff
+└── jpeg
+
+libtool
+
+libunistring
+
+libyaml
+
+little-cms2
+├── jpeg
+└── libtiff
+    └── jpeg
+
+maven
+
+mercurial
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+node
+└── icu4c
+
+node@10
+└── icu4c
+
+openexr
+└── ilmbase
+
+openjpeg
+├── libpng
+├── libtiff
+│   └── jpeg
+└── little-cms2
+    ├── jpeg
+    └── libtiff
+        └── jpeg
+
+openssl
+
+pcre
+
+pcre2
+
+pkg-config
+
+python
+├── gdbm
+├── openssl@1.1
+├── readline
+├── sqlite
+│   └── readline
+└── xz
+
+python@2
+├── gdbm
+├── openssl@1.1
+├── readline
+└── sqlite
+    └── readline
+
+rbenv
+└── ruby-build
+    ├── autoconf
+    ├── pkg-config
+    └── readline
+
+readline
+
+ruby-build
+├── autoconf
+├── pkg-config
+└── readline
+
+screen
+
+shared-mime-info
+├── gettext
+└── glib
+    ├── gettext
+    ├── libffi
+    ├── pcre
+    └── python
+        ├── gdbm
+        ├── openssl@1.1
+        ├── readline
+        ├── sqlite
+        │   └── readline
+        └── xz
+
+sqlite
+└── readline
+
+tree
+
+watchman
+├── openssl@1.1
+├── pcre
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+webp
+├── jpeg
+├── libpng
+└── libtiff
+    └── jpeg
+
+wget
+├── libidn2
+│   ├── gettext
+│   └── libunistring
+└── openssl@1.1
+
+x265
+
+xz
+
+yarn
+└── node
+    └── icu4c
+
 ========================================
 
 
@@ -711,18 +1047,18 @@ Software:
       Kernel Version: Darwin 18.5.0
       Boot Volume: Untitled
       Boot Mode: Normal
-      Computer Name: stg-xcode-10-2-191128162417-mtfNpJVzXEDBjTjhBRJuPd
+      Computer Name: prd-std-g-xcode-10-2-191204105132-Aa46ukoYfjvTqhi7rDTH28
       User Name: vagrant (vagrant)
       Secure Virtual Memory: Enabled
       System Integrity Protection: Disabled
-      Time since boot: 23 minutes
+      Time since boot: 6 minutes
 
 
 ========================================
 
 
 === System infos =======================
-* Free disk space: /dev/disk1s1  200Gi  136Gi   63Gi    69% 4423969 9223372036850351838    0%   /
+* Free disk space: /dev/disk1s1  200Gi  136Gi   63Gi    69% 4417890 9223372036850357917    0%   /
 ========================================
 
 --- Android

--- a/system_reports/osx-xcode-10.3.x.log
+++ b/system_reports/osx-xcode-10.3.x.log
@@ -33,9 +33,9 @@ OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.222-b10, mixed mode)
 * tar: bsdtar 2.8.3 - libarchive 2.8.3
 * tree: tree v1.8.0 (c) 1996 - 2018 by Steve Baker, Thomas Moore, Francesc Rocher, Florian Sesser, Kyosuke Tokoro 
 
-* brew: Homebrew 2.2.0
-Homebrew/homebrew-core (git revision c2ba6; last commit 2019-11-27)
-Homebrew/homebrew-cask (git revision 60b11; last commit 2019-11-28)
+* brew: Homebrew 2.1.16
+Homebrew/homebrew-core (git revision 079ce5; last commit 2019-11-21)
+Homebrew/homebrew-cask (git revision b6142; last commit 2019-11-21)
 ./system_report.sh: line 58: xctool: command not found
 * xctool: 
 * Ansible: ansible 2.8.2
@@ -64,6 +64,342 @@ Error: No previously deleted formula found.
 * stepman: 0.11.11
 * envman: 2.2.9
 * cmd-bridge: 0.9.5
+========================================
+
+
+=== Brew list versions ==================
+ansible 2.8.2
+ant 1.10.6
+autoconf 2.69
+carthage 0.33.0
+coreutils 8.31
+flow 0.102.0
+freetype 2.10.1
+gdbm 1.18.1
+gettext 0.20.1
+ghostscript 9.27_1
+git 2.22.0_1
+git-lfs 2.7.2
+glib 2.60.5
+go 1.12.7
+gradle 5.5.1
+icu4c 64.2
+ilmbase 2.3.0
+imagemagick 7.0.8-53
+jenv 0.5.2
+jpeg 9c
+libde265 1.0.3
+libffi 3.2.1
+libheif 1.4.0_1
+libidn2 2.2.0_1
+libomp 8.0.0
+libpng 1.6.37
+libtiff 4.0.10_1
+libtool 2.4.6_1
+libunistring 0.9.10
+libyaml 0.2.2
+little-cms2 2.9
+maven 3.6.1
+mercurial 5.0.2
+node 12.6.0
+node@10 10.16.0
+openexr 2.3.0
+openjpeg 2.3.1
+openssl 1.0.2s
+pcre 8.43
+pcre2 10.33
+pkg-config 0.29.2
+python 3.7.4
+python@2 2.7.16
+rbenv 1.1.2
+readline 8.0.0_1
+ruby-build 20190615
+screen 4.6.2
+shared-mime-info 1.12_1
+sqlite 3.29.0
+tree 1.8.0
+watchman 4.9.0_2
+webp 1.0.3
+wget 1.20.3_1
+x265 3.1.1
+xz 5.2.4
+yarn 1.17.3
+========================================
+
+
+=== Brew deps tree ==================
+ansible
+├── libyaml
+├── openssl@1.1
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+ant
+
+autoconf
+
+carthage
+
+coreutils
+
+flow
+
+freetype
+└── libpng
+
+gdbm
+
+gettext
+
+ghostscript
+└── libtiff
+    └── jpeg
+
+git
+├── gettext
+└── pcre2
+
+git-lfs
+
+glib
+├── gettext
+├── libffi
+├── pcre
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+go
+
+gradle
+
+icu4c
+
+ilmbase
+
+imagemagick
+├── freetype
+│   └── libpng
+├── jpeg
+├── libheif
+│   ├── jpeg
+│   ├── libde265
+│   ├── libpng
+│   ├── shared-mime-info
+│   │   ├── gettext
+│   │   └── glib
+│   │       ├── gettext
+│   │       ├── libffi
+│   │       ├── pcre
+│   │       └── python
+│   │           ├── gdbm
+│   │           ├── openssl@1.1
+│   │           ├── readline
+│   │           ├── sqlite
+│   │           │   └── readline
+│   │           └── xz
+│   └── x265
+├── libomp
+├── libpng
+├── libtiff
+│   └── jpeg
+├── libtool
+├── little-cms2
+│   ├── jpeg
+│   └── libtiff
+│       └── jpeg
+├── openexr
+│   └── ilmbase
+├── openjpeg
+│   ├── libpng
+│   ├── libtiff
+│   │   └── jpeg
+│   └── little-cms2
+│       ├── jpeg
+│       └── libtiff
+│           └── jpeg
+├── webp
+│   ├── jpeg
+│   ├── libpng
+│   └── libtiff
+│       └── jpeg
+└── xz
+
+jenv
+
+jpeg
+
+libde265
+
+libffi
+
+libheif
+├── jpeg
+├── libde265
+├── libpng
+├── shared-mime-info
+│   ├── gettext
+│   └── glib
+│       ├── gettext
+│       ├── libffi
+│       ├── pcre
+│       └── python
+│           ├── gdbm
+│           ├── openssl@1.1
+│           ├── readline
+│           ├── sqlite
+│           │   └── readline
+│           └── xz
+└── x265
+
+libidn2
+├── gettext
+└── libunistring
+
+libomp
+
+libpng
+
+libtiff
+└── jpeg
+
+libtool
+
+libunistring
+
+libyaml
+
+little-cms2
+├── jpeg
+└── libtiff
+    └── jpeg
+
+maven
+
+mercurial
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+node
+└── icu4c
+
+node@10
+└── icu4c
+
+openexr
+└── ilmbase
+
+openjpeg
+├── libpng
+├── libtiff
+│   └── jpeg
+└── little-cms2
+    ├── jpeg
+    └── libtiff
+        └── jpeg
+
+openssl
+
+pcre
+
+pcre2
+
+pkg-config
+
+python
+├── gdbm
+├── openssl@1.1
+├── readline
+├── sqlite
+│   └── readline
+└── xz
+
+python@2
+├── gdbm
+├── openssl@1.1
+├── readline
+└── sqlite
+    └── readline
+
+rbenv
+└── ruby-build
+    ├── autoconf
+    ├── pkg-config
+    └── readline
+
+readline
+
+ruby-build
+├── autoconf
+├── pkg-config
+└── readline
+
+screen
+
+shared-mime-info
+├── gettext
+└── glib
+    ├── gettext
+    ├── libffi
+    ├── pcre
+    └── python
+        ├── gdbm
+        ├── openssl@1.1
+        ├── readline
+        ├── sqlite
+        │   └── readline
+        └── xz
+
+sqlite
+└── readline
+
+tree
+
+watchman
+├── openssl@1.1
+├── pcre
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+webp
+├── jpeg
+├── libpng
+└── libtiff
+    └── jpeg
+
+wget
+├── libidn2
+│   ├── gettext
+│   └── libunistring
+└── openssl@1.1
+
+x265
+
+xz
+
+yarn
+└── node
+    └── icu4c
+
 ========================================
 
 
@@ -710,18 +1046,18 @@ Software:
       Kernel Version: Darwin 18.7.0
       Boot Volume: Untitled
       Boot Mode: Normal
-      Computer Name: stg-xcode-10-3-191128163145-kp3LTocopZQPWLF5ADvqAL
+      Computer Name: prd-std-b-xcode-10-3-191204104145-49iunPvPiRC5XPNmJekeqK
       User Name: vagrant (vagrant)
       Secure Virtual Memory: Enabled
       System Integrity Protection: Disabled
-      Time since boot: 14 minutes
+      Time since boot: 15 minutes
 
 
 ========================================
 
 
 === System infos =======================
-* Free disk space: /dev/disk1s1  200Gi  138Gi   61Gi    70% 4314398 9223372036850461409    0%   /
+* Free disk space: /dev/disk1s1  200Gi  138Gi   61Gi    70% 4310477 9223372036850465330    0%   /
 ========================================
 
 --- Android

--- a/system_reports/osx-xcode-11.0.x.log
+++ b/system_reports/osx-xcode-11.0.x.log
@@ -33,9 +33,9 @@ OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.222-b10, mixed mode)
 * tar: bsdtar 2.8.3 - libarchive 2.8.3
 * tree: tree v1.8.0 (c) 1996 - 2018 by Steve Baker, Thomas Moore, Francesc Rocher, Florian Sesser, Kyosuke Tokoro 
 
-* brew: Homebrew 2.2.0
-Homebrew/homebrew-core (git revision c2ba6; last commit 2019-11-27)
-Homebrew/homebrew-cask (git revision 60b11; last commit 2019-11-28)
+* brew: Homebrew 2.1.16
+Homebrew/homebrew-core (git revision 079ce5; last commit 2019-11-21)
+Homebrew/homebrew-cask (git revision b6142; last commit 2019-11-21)
 ./system_report.sh: line 58: xctool: command not found
 * xctool: 
 * Ansible: ansible 2.8.3
@@ -64,6 +64,342 @@ Error: No previously deleted formula found.
 * stepman: 0.11.11
 * envman: 2.2.9
 * cmd-bridge: 0.9.5
+========================================
+
+
+=== Brew list versions ==================
+ansible 2.8.3
+ant 1.10.6
+autoconf 2.69
+carthage 0.33.0
+coreutils 8.31
+flow 0.102.0
+freetype 2.10.1
+gdbm 1.18.1
+gettext 0.20.1
+ghostscript 9.27_1
+git 2.22.0_1
+git-lfs 2.8.0
+glib 2.60.6
+go 1.12.7
+gradle 5.5.1
+icu4c 64.2
+ilmbase 2.3.0
+imagemagick 7.0.8-56
+jenv 0.5.2
+jpeg 9c
+libde265 1.0.3
+libffi 3.2.1
+libheif 1.4.0_1
+libidn2 2.2.0_1
+libomp 8.0.0
+libpng 1.6.37
+libtiff 4.0.10_1
+libtool 2.4.6_1
+libunistring 0.9.10
+libyaml 0.2.2
+little-cms2 2.9
+maven 3.6.1
+mercurial 5.0.2
+node 12.6.0
+node@10 10.16.0
+openexr 2.3.0
+openjpeg 2.3.1
+openssl 1.0.2s
+pcre 8.43
+pcre2 10.33
+pkg-config 0.29.2
+python 3.7.4
+python@2 2.7.16
+rbenv 1.1.2
+readline 8.0.0_1
+ruby-build 20190615
+screen 4.6.2
+shared-mime-info 1.12_1
+sqlite 3.29.0
+tree 1.8.0
+watchman 4.9.0_2
+webp 1.0.3
+wget 1.20.3_1
+x265 3.1.1
+xz 5.2.4
+yarn 1.17.3
+========================================
+
+
+=== Brew deps tree ==================
+ansible
+├── libyaml
+├── openssl@1.1
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+ant
+
+autoconf
+
+carthage
+
+coreutils
+
+flow
+
+freetype
+└── libpng
+
+gdbm
+
+gettext
+
+ghostscript
+└── libtiff
+    └── jpeg
+
+git
+├── gettext
+└── pcre2
+
+git-lfs
+
+glib
+├── gettext
+├── libffi
+├── pcre
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+go
+
+gradle
+
+icu4c
+
+ilmbase
+
+imagemagick
+├── freetype
+│   └── libpng
+├── jpeg
+├── libheif
+│   ├── jpeg
+│   ├── libde265
+│   ├── libpng
+│   ├── shared-mime-info
+│   │   ├── gettext
+│   │   └── glib
+│   │       ├── gettext
+│   │       ├── libffi
+│   │       ├── pcre
+│   │       └── python
+│   │           ├── gdbm
+│   │           ├── openssl@1.1
+│   │           ├── readline
+│   │           ├── sqlite
+│   │           │   └── readline
+│   │           └── xz
+│   └── x265
+├── libomp
+├── libpng
+├── libtiff
+│   └── jpeg
+├── libtool
+├── little-cms2
+│   ├── jpeg
+│   └── libtiff
+│       └── jpeg
+├── openexr
+│   └── ilmbase
+├── openjpeg
+│   ├── libpng
+│   ├── libtiff
+│   │   └── jpeg
+│   └── little-cms2
+│       ├── jpeg
+│       └── libtiff
+│           └── jpeg
+├── webp
+│   ├── jpeg
+│   ├── libpng
+│   └── libtiff
+│       └── jpeg
+└── xz
+
+jenv
+
+jpeg
+
+libde265
+
+libffi
+
+libheif
+├── jpeg
+├── libde265
+├── libpng
+├── shared-mime-info
+│   ├── gettext
+│   └── glib
+│       ├── gettext
+│       ├── libffi
+│       ├── pcre
+│       └── python
+│           ├── gdbm
+│           ├── openssl@1.1
+│           ├── readline
+│           ├── sqlite
+│           │   └── readline
+│           └── xz
+└── x265
+
+libidn2
+├── gettext
+└── libunistring
+
+libomp
+
+libpng
+
+libtiff
+└── jpeg
+
+libtool
+
+libunistring
+
+libyaml
+
+little-cms2
+├── jpeg
+└── libtiff
+    └── jpeg
+
+maven
+
+mercurial
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+node
+└── icu4c
+
+node@10
+└── icu4c
+
+openexr
+└── ilmbase
+
+openjpeg
+├── libpng
+├── libtiff
+│   └── jpeg
+└── little-cms2
+    ├── jpeg
+    └── libtiff
+        └── jpeg
+
+openssl
+
+pcre
+
+pcre2
+
+pkg-config
+
+python
+├── gdbm
+├── openssl@1.1
+├── readline
+├── sqlite
+│   └── readline
+└── xz
+
+python@2
+├── gdbm
+├── openssl@1.1
+├── readline
+└── sqlite
+    └── readline
+
+rbenv
+└── ruby-build
+    ├── autoconf
+    ├── pkg-config
+    └── readline
+
+readline
+
+ruby-build
+├── autoconf
+├── pkg-config
+└── readline
+
+screen
+
+shared-mime-info
+├── gettext
+└── glib
+    ├── gettext
+    ├── libffi
+    ├── pcre
+    └── python
+        ├── gdbm
+        ├── openssl@1.1
+        ├── readline
+        ├── sqlite
+        │   └── readline
+        └── xz
+
+sqlite
+└── readline
+
+tree
+
+watchman
+├── openssl@1.1
+├── pcre
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+webp
+├── jpeg
+├── libpng
+└── libtiff
+    └── jpeg
+
+wget
+├── libidn2
+│   ├── gettext
+│   └── libunistring
+└── openssl@1.1
+
+x265
+
+xz
+
+yarn
+└── node
+    └── icu4c
+
 ========================================
 
 
@@ -712,18 +1048,18 @@ Software:
       Kernel Version: Darwin 18.7.0
       Boot Volume: Untitled
       Boot Mode: Normal
-      Computer Name: stg-xcode-11-191128162417-cGLiL6qi6N9Uksmp9xeEWY
+      Computer Name: prd-std-g-xcode-11-191204105047-QFrc8JUhZxbVRPZKqigiMF
       User Name: vagrant (vagrant)
       Secure Virtual Memory: Enabled
       System Integrity Protection: Disabled
-      Time since boot: 21 minutes
+      Time since boot: 6 minutes
 
 
 ========================================
 
 
 === System infos =======================
-* Free disk space: /dev/disk1s1  200Gi  148Gi   51Gi    75% 4376029 9223372036850399778    0%   /
+* Free disk space: /dev/disk1s1  200Gi  148Gi   51Gi    75% 4372779 9223372036850403028    0%   /
 ========================================
 
 --- Android

--- a/system_reports/osx-xcode-11.1.x.log
+++ b/system_reports/osx-xcode-11.1.x.log
@@ -33,9 +33,9 @@ OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.222-b10, mixed mode)
 * tar: bsdtar 2.8.3 - libarchive 2.8.3
 * tree: tree v1.8.0 (c) 1996 - 2018 by Steve Baker, Thomas Moore, Francesc Rocher, Florian Sesser, Kyosuke Tokoro 
 
-* brew: Homebrew 2.2.0
-Homebrew/homebrew-core (git revision c2ba6; last commit 2019-11-27)
-Homebrew/homebrew-cask (git revision 60b11; last commit 2019-11-28)
+* brew: Homebrew 2.1.16
+Homebrew/homebrew-core (git revision 079ce5; last commit 2019-11-21)
+Homebrew/homebrew-cask (git revision b6142; last commit 2019-11-21)
 ./system_report.sh: line 58: xctool: command not found
 * xctool: 
 * Ansible: ansible 2.8.3
@@ -64,6 +64,342 @@ Error: No previously deleted formula found.
 * stepman: 0.11.11
 * envman: 2.2.9
 * cmd-bridge: 0.9.5
+========================================
+
+
+=== Brew list versions ==================
+ansible 2.8.3
+ant 1.10.6
+autoconf 2.69
+carthage 0.33.0
+coreutils 8.31
+flow 0.102.0
+freetype 2.10.1
+gdbm 1.18.1
+gettext 0.20.1
+ghostscript 9.27_1
+git 2.22.0_1
+git-lfs 2.8.0
+glib 2.60.6
+go 1.12.7
+gradle 5.5.1
+icu4c 64.2
+ilmbase 2.3.0
+imagemagick 7.0.8-56
+jenv 0.5.2
+jpeg 9c
+libde265 1.0.3
+libffi 3.2.1
+libheif 1.4.0_1
+libidn2 2.2.0_1
+libomp 8.0.0
+libpng 1.6.37
+libtiff 4.0.10_1
+libtool 2.4.6_1
+libunistring 0.9.10
+libyaml 0.2.2
+little-cms2 2.9
+maven 3.6.1
+mercurial 5.0.2
+node 12.6.0
+node@10 10.16.0
+openexr 2.3.0
+openjpeg 2.3.1
+openssl 1.0.2s
+pcre 8.43
+pcre2 10.33
+pkg-config 0.29.2
+python 3.7.4
+python@2 2.7.16
+rbenv 1.1.2
+readline 8.0.0_1
+ruby-build 20190615
+screen 4.6.2
+shared-mime-info 1.12_1
+sqlite 3.29.0
+tree 1.8.0
+watchman 4.9.0_2
+webp 1.0.3
+wget 1.20.3_1
+x265 3.1.1
+xz 5.2.4
+yarn 1.17.3
+========================================
+
+
+=== Brew deps tree ==================
+ansible
+├── libyaml
+├── openssl@1.1
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+ant
+
+autoconf
+
+carthage
+
+coreutils
+
+flow
+
+freetype
+└── libpng
+
+gdbm
+
+gettext
+
+ghostscript
+└── libtiff
+    └── jpeg
+
+git
+├── gettext
+└── pcre2
+
+git-lfs
+
+glib
+├── gettext
+├── libffi
+├── pcre
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+go
+
+gradle
+
+icu4c
+
+ilmbase
+
+imagemagick
+├── freetype
+│   └── libpng
+├── jpeg
+├── libheif
+│   ├── jpeg
+│   ├── libde265
+│   ├── libpng
+│   ├── shared-mime-info
+│   │   ├── gettext
+│   │   └── glib
+│   │       ├── gettext
+│   │       ├── libffi
+│   │       ├── pcre
+│   │       └── python
+│   │           ├── gdbm
+│   │           ├── openssl@1.1
+│   │           ├── readline
+│   │           ├── sqlite
+│   │           │   └── readline
+│   │           └── xz
+│   └── x265
+├── libomp
+├── libpng
+├── libtiff
+│   └── jpeg
+├── libtool
+├── little-cms2
+│   ├── jpeg
+│   └── libtiff
+│       └── jpeg
+├── openexr
+│   └── ilmbase
+├── openjpeg
+│   ├── libpng
+│   ├── libtiff
+│   │   └── jpeg
+│   └── little-cms2
+│       ├── jpeg
+│       └── libtiff
+│           └── jpeg
+├── webp
+│   ├── jpeg
+│   ├── libpng
+│   └── libtiff
+│       └── jpeg
+└── xz
+
+jenv
+
+jpeg
+
+libde265
+
+libffi
+
+libheif
+├── jpeg
+├── libde265
+├── libpng
+├── shared-mime-info
+│   ├── gettext
+│   └── glib
+│       ├── gettext
+│       ├── libffi
+│       ├── pcre
+│       └── python
+│           ├── gdbm
+│           ├── openssl@1.1
+│           ├── readline
+│           ├── sqlite
+│           │   └── readline
+│           └── xz
+└── x265
+
+libidn2
+├── gettext
+└── libunistring
+
+libomp
+
+libpng
+
+libtiff
+└── jpeg
+
+libtool
+
+libunistring
+
+libyaml
+
+little-cms2
+├── jpeg
+└── libtiff
+    └── jpeg
+
+maven
+
+mercurial
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+node
+└── icu4c
+
+node@10
+└── icu4c
+
+openexr
+└── ilmbase
+
+openjpeg
+├── libpng
+├── libtiff
+│   └── jpeg
+└── little-cms2
+    ├── jpeg
+    └── libtiff
+        └── jpeg
+
+openssl
+
+pcre
+
+pcre2
+
+pkg-config
+
+python
+├── gdbm
+├── openssl@1.1
+├── readline
+├── sqlite
+│   └── readline
+└── xz
+
+python@2
+├── gdbm
+├── openssl@1.1
+├── readline
+└── sqlite
+    └── readline
+
+rbenv
+└── ruby-build
+    ├── autoconf
+    ├── pkg-config
+    └── readline
+
+readline
+
+ruby-build
+├── autoconf
+├── pkg-config
+└── readline
+
+screen
+
+shared-mime-info
+├── gettext
+└── glib
+    ├── gettext
+    ├── libffi
+    ├── pcre
+    └── python
+        ├── gdbm
+        ├── openssl@1.1
+        ├── readline
+        ├── sqlite
+        │   └── readline
+        └── xz
+
+sqlite
+└── readline
+
+tree
+
+watchman
+├── openssl@1.1
+├── pcre
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+webp
+├── jpeg
+├── libpng
+└── libtiff
+    └── jpeg
+
+wget
+├── libidn2
+│   ├── gettext
+│   └── libunistring
+└── openssl@1.1
+
+x265
+
+xz
+
+yarn
+└── node
+    └── icu4c
+
 ========================================
 
 
@@ -708,18 +1044,18 @@ Software:
       Kernel Version: Darwin 18.7.0
       Boot Volume: Untitled
       Boot Mode: Normal
-      Computer Name: stg-xcode-11-1-191128162417-BdLjqe4kVPDPHHjBEPW4XV
+      Computer Name: prd-std-g-xcode-11-1-191204105347-DUuwyiEkwaeHHmAuuw9ZHD
       User Name: vagrant (vagrant)
       Secure Virtual Memory: Enabled
       System Integrity Protection: Disabled
-      Time since boot: 19 minutes
+      Time since boot: 3 minutes
 
 
 ========================================
 
 
 === System infos =======================
-* Free disk space: /dev/disk1s1  200Gi  151Gi   49Gi    76% 4381916 9223372036850393891    0%   /
+* Free disk space: /dev/disk1s1  200Gi  151Gi   48Gi    76% 4377635 9223372036850398172    0%   /
 ========================================
 
 --- Android

--- a/system_reports/osx-xcode-11.2.x.log
+++ b/system_reports/osx-xcode-11.2.x.log
@@ -33,9 +33,9 @@ OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.222-b10, mixed mode)
 * tar: bsdtar 2.8.3 - libarchive 2.8.3
 * tree: tree v1.8.0 (c) 1996 - 2018 by Steve Baker, Thomas Moore, Francesc Rocher, Florian Sesser, Kyosuke Tokoro 
 
-* brew: Homebrew 2.2.0
-Homebrew/homebrew-core (git revision 808d3; last commit 2019-11-28)
-Homebrew/homebrew-cask (git revision e245b; last commit 2019-11-28)
+* brew: Homebrew 2.1.16
+Homebrew/homebrew-core (git revision 079c; last commit 2019-11-21)
+Homebrew/homebrew-cask (git revision b6142; last commit 2019-11-21)
 ./system_report.sh: line 58: xctool: command not found
 * xctool: 
 * Ansible: ansible 2.8.5
@@ -67,13 +67,352 @@ Error: No previously deleted formula found.
 ========================================
 
 
+=== Brew list versions ==================
+ansible 2.8.5
+ant 1.10.7
+autoconf 2.69
+carthage 0.33.0
+coreutils 8.31
+flow 0.109.0
+freetype 2.10.1
+gdbm 1.18.1
+gettext 0.20.1
+ghostscript 9.27_1
+git 2.23.0_1
+git-lfs 2.8.0
+glib 2.62.0_1
+go 1.13.1
+gradle 5.6.2
+icu4c 64.2
+ilmbase 2.3.0
+imagemagick 7.0.8-66
+jenv 0.5.2
+jpeg 9c
+libde265 1.0.3
+libffi 3.2.1
+libheif 1.5.1
+libidn2 2.2.0_1
+libomp 9.0.0
+libpng 1.6.37
+libtiff 4.0.10_1
+libtool 2.4.6_1
+libunistring 0.9.10
+libyaml 0.2.2
+little-cms2 2.9
+maven 3.6.2
+mercurial 5.1.1_2
+node 12.11.1
+node@10 10.16.3
+openexr 2.3.0
+openjpeg 2.3.1
+openssl@1.1 1.1.1d
+pcre 8.43
+pcre2 10.33
+pkg-config 0.29.2
+python 3.7.4_1
+python@2 2.7.16_1
+rbenv 1.1.2
+readline 8.0.1
+ruby-build 20191004
+screen 4.6.2
+shared-mime-info 1.14
+sqlite 3.29.0
+tree 1.8.0
+watchman 4.9.0_3
+webp 1.0.3
+wget 1.20.3_1
+x265 3.1.2
+xz 5.2.4
+yarn 1.19.0
+========================================
+
+
+=== Brew deps tree ==================
+ansible
+├── libyaml
+├── openssl@1.1
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+ant
+
+autoconf
+
+carthage
+
+coreutils
+
+flow
+
+freetype
+└── libpng
+
+gdbm
+
+gettext
+
+ghostscript
+└── libtiff
+    └── jpeg
+
+git
+├── gettext
+└── pcre2
+
+git-lfs
+
+glib
+├── gettext
+├── libffi
+├── pcre
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+go
+
+gradle
+
+icu4c
+
+ilmbase
+
+imagemagick
+├── freetype
+│   └── libpng
+├── jpeg
+├── libheif
+│   ├── jpeg
+│   ├── libde265
+│   ├── libpng
+│   ├── shared-mime-info
+│   │   ├── gettext
+│   │   └── glib
+│   │       ├── gettext
+│   │       ├── libffi
+│   │       ├── pcre
+│   │       └── python
+│   │           ├── gdbm
+│   │           ├── openssl@1.1
+│   │           ├── readline
+│   │           ├── sqlite
+│   │           │   └── readline
+│   │           └── xz
+│   └── x265
+├── libomp
+├── libpng
+├── libtiff
+│   └── jpeg
+├── libtool
+├── little-cms2
+│   ├── jpeg
+│   └── libtiff
+│       └── jpeg
+├── openexr
+│   └── ilmbase
+├── openjpeg
+│   ├── libpng
+│   ├── libtiff
+│   │   └── jpeg
+│   └── little-cms2
+│       ├── jpeg
+│       └── libtiff
+│           └── jpeg
+├── webp
+│   ├── jpeg
+│   ├── libpng
+│   └── libtiff
+│       └── jpeg
+└── xz
+
+jenv
+
+jpeg
+
+libde265
+
+libffi
+
+libheif
+├── jpeg
+├── libde265
+├── libpng
+├── shared-mime-info
+│   ├── gettext
+│   └── glib
+│       ├── gettext
+│       ├── libffi
+│       ├── pcre
+│       └── python
+│           ├── gdbm
+│           ├── openssl@1.1
+│           ├── readline
+│           ├── sqlite
+│           │   └── readline
+│           └── xz
+└── x265
+
+libidn2
+├── gettext
+└── libunistring
+
+libomp
+
+libpng
+
+libtiff
+└── jpeg
+
+libtool
+
+libunistring
+
+libyaml
+
+little-cms2
+├── jpeg
+└── libtiff
+    └── jpeg
+
+maven
+
+mercurial
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+node
+└── icu4c
+
+node@10
+└── icu4c
+
+openexr
+└── ilmbase
+
+openjpeg
+├── libpng
+├── libtiff
+│   └── jpeg
+└── little-cms2
+    ├── jpeg
+    └── libtiff
+        └── jpeg
+
+openssl@1.1
+
+pcre
+
+pcre2
+
+pkg-config
+
+python
+├── gdbm
+├── openssl@1.1
+├── readline
+├── sqlite
+│   └── readline
+└── xz
+
+python@2
+├── gdbm
+├── openssl@1.1
+├── readline
+└── sqlite
+    └── readline
+
+rbenv
+└── ruby-build
+    ├── autoconf
+    ├── pkg-config
+    └── readline
+
+readline
+
+ruby-build
+├── autoconf
+├── pkg-config
+└── readline
+
+screen
+
+shared-mime-info
+├── gettext
+└── glib
+    ├── gettext
+    ├── libffi
+    ├── pcre
+    └── python
+        ├── gdbm
+        ├── openssl@1.1
+        ├── readline
+        ├── sqlite
+        │   └── readline
+        └── xz
+
+sqlite
+└── readline
+
+tree
+
+watchman
+├── openssl@1.1
+├── pcre
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+webp
+├── jpeg
+├── libpng
+└── libtiff
+    └── jpeg
+
+wget
+├── libidn2
+│   ├── gettext
+│   └── libunistring
+└── openssl@1.1
+
+x265
+
+xz
+
+yarn
+└── node
+    └── icu4c
+
+========================================
+
+
 === Ruby and rubygems ==================
-* Ruby (default): ruby 2.6.5p114 (2019-10-01 revision 67812) [x86_64-darwin18]
+* Ruby (default): ruby 2.6.3p62 (2019-04-16 revision 67580) [x86_64-darwin18]
 --- Available ruby versions ---
   system
+  2.4.5
   2.4.9
+  2.5.3
   2.5.7
-* 2.6.5 (set by /Users/vagrant/.rbenv/version)
+* 2.6.3 (set by /Users/vagrant/.rbenv/version)
+  2.6.5
 -------------------------------
 * rbenv: 1.1.2
 * Rubygems: 3.0.6
@@ -99,8 +438,8 @@ certified (1.0.0)
 CFPropertyList (3.0.1)
 claide (1.0.3)
 cmath (default: 1.0.0)
-cocoapods (1.8.4, 1.8.1)
-cocoapods-core (1.8.4, 1.8.1)
+cocoapods (1.8.4)
+cocoapods-core (1.8.4)
 cocoapods-deintegrate (1.0.4)
 cocoapods-downloader (1.2.2)
 cocoapods-plugins (1.0.0)
@@ -128,12 +467,12 @@ e2mmap (default: 0.1.0)
 emoji_regex (1.0.1)
 escape (0.0.4)
 etc (default: 1.0.1)
-excon (0.67.0)
-faraday (0.16.2, 0.15.4)
+excon (0.68.0)
+faraday (0.17.0)
 faraday-cookie_jar (0.0.6)
 faraday_middleware (0.13.1)
 fastimage (2.1.7)
-fastlane (2.133.0)
+fastlane (2.134.0)
 fcntl (default: 1.0.0)
 fiddle (default: 1.0.0)
 fileutils (default: 1.1.0)
@@ -143,11 +482,11 @@ fuzzy_match (2.0.4)
 gdbm (default: 2.0.0)
 gh_inspector (1.1.3)
 google-api-client (0.23.9)
-google-cloud-core (1.3.1)
-google-cloud-env (1.2.1)
+google-cloud-core (1.4.1)
+google-cloud-env (1.3.0)
 google-cloud-storage (1.16.0)
 googleauth (0.6.7)
-highline (2.0.2, 1.7.10)
+highline (2.0.3, 1.7.10)
 houston (2.4.0)
 http-cookie (1.0.3)
 httpclient (2.8.3)
@@ -162,12 +501,12 @@ matrix (default: 0.1.0)
 mechanize (2.5.1)
 memoist (0.16.0)
 mime-types (3.3, 1.25.1)
-mime-types-data (3.2019.0904)
+mime-types-data (3.2019.1009)
 mini_magick (4.9.5)
 mini_portile2 (2.1.0)
 minitest (5.11.3)
 molinillo (0.6.6)
-multi_json (1.13.1)
+multi_json (1.14.1)
 multi_xml (0.6.0)
 multipart-post (2.1.1, 2.0.0)
 mutex_m (default: 0.1.0)
@@ -194,7 +533,7 @@ public_suffix (2.0.5)
 rack (1.6.11)
 rack-protection (1.5.5)
 rake (12.3.2)
-rdoc (default: 6.1.2)
+rdoc (default: 6.1.0)
 representable (3.0.4)
 retriable (3.1.2)
 rexml (default: 3.1.9)
@@ -208,7 +547,7 @@ sdbm (default: 1.0.0)
 security (0.1.3)
 shell (default: 0.7)
 shenzhen (0.14.3)
-signet (0.11.0)
+signet (0.12.0)
 simctl (1.6.6)
 sinatra (1.4.8)
 slack-notifier (2.3.2)
@@ -234,7 +573,7 @@ venice (0.5.0)
 webrick (default: 1.4.2)
 webrobots (0.1.2)
 word_wrap (1.0.0)
-xcodeproj (1.12.0)
+xcodeproj (1.13.0)
 xcpretty (0.3.0)
 xcpretty-travis-formatter (1.0.0)
 xmlrpc (0.3.0)
@@ -366,8 +705,6 @@ iOS 12.0 (12.0 - 16A366) - com.apple.CoreSimulator.SimRuntime.iOS-12-0
 iOS 12.1 (12.1 - 16B91) - com.apple.CoreSimulator.SimRuntime.iOS-12-1 
 iOS 12.2 (12.2 - 16E226) - com.apple.CoreSimulator.SimRuntime.iOS-12-2 
 iOS 12.4 (12.4 - 16G73) - com.apple.CoreSimulator.SimRuntime.iOS-12-4 
-iOS 13.0 (13.0 - 17A577) - com.apple.CoreSimulator.SimRuntime.iOS-13-0 
-iOS 13.1 (13.1 - 17A844) - com.apple.CoreSimulator.SimRuntime.iOS-13-1 
 iOS 13.2 (13.2.2 - 17B102) - com.apple.CoreSimulator.SimRuntime.iOS-13-2 
 tvOS 10.2 (10.2 - 14W260) - com.apple.CoreSimulator.SimRuntime.tvOS-10-2 
 tvOS 11.0 (11.0 - 15J380) - com.apple.CoreSimulator.SimRuntime.tvOS-11-0 
@@ -388,7 +725,6 @@ watchOS 5.0 (5.0 - 16R363) - com.apple.CoreSimulator.SimRuntime.watchOS-5-0
 watchOS 5.1 (5.1 - 16R591) - com.apple.CoreSimulator.SimRuntime.watchOS-5-1 
 watchOS 5.2 (5.2 - 16T224) - com.apple.CoreSimulator.SimRuntime.watchOS-5-2 
 watchOS 5.3 (5.3 - 16U567) - com.apple.CoreSimulator.SimRuntime.watchOS-5-3 
-watchOS 6.0 (6.0 - 17R575) - com.apple.CoreSimulator.SimRuntime.watchOS-6-0 
 watchOS 6.1 (6.1 - 17S83) - com.apple.CoreSimulator.SimRuntime.watchOS-6-1 
 == Devices ==
 -- iOS 10.3 --
@@ -603,26 +939,6 @@ watchOS 6.1 (6.1 - 17S83) - com.apple.CoreSimulator.SimRuntime.watchOS-6-1
     iPad Pro (11-inch) (FF9112B3-B40F-4A23-A94D-DBF8F1A232FB) (Shutdown) 
     iPad Pro (12.9-inch) (3rd generation) (81B34853-B7B7-4629-93D8-902D888E73D3) (Shutdown) 
     iPad Air (3rd generation) (444A91A1-EAD7-4F6B-8EC5-EA5F039F09B1) (Shutdown) 
--- iOS 13.0 --
-    iPhone 8 (BAB6DAB1-F34B-4556-982E-411E19F4476B) (Shutdown) 
-    iPhone 8 Plus (E3FB30EC-9D60-4CDC-BDD9-4E72EC9218BC) (Shutdown) 
-    iPhone 11 (C229DD1B-3CE6-4952-B8A7-C96062995FA9) (Shutdown) 
-    iPhone 11 Pro (F86E4687-4DBB-4DBE-8785-F9077D0051A5) (Shutdown) 
-    iPhone 11 Pro Max (6F7364EF-D179-40B3-AAE8-847FE677D073) (Shutdown) 
-    iPad Pro (9.7-inch) (87709C1B-A2A5-44F2-90EB-A0CF04325575) (Shutdown) 
-    iPad Pro (11-inch) (84D7408C-2A44-4B30-A83A-0FFA2303EBA7) (Shutdown) 
-    iPad Pro (12.9-inch) (3rd generation) (B466AAC3-1E2A-427F-B18E-DA33AFD56CDD) (Shutdown) 
-    iPad Air (3rd generation) (9AFBFBB7-00BF-4BB8-8C1C-1FEDD4928FF8) (Shutdown) 
--- iOS 13.1 --
-    iPhone 8 (46121397-1271-47FC-ADEC-14C573F8B1C7) (Shutdown) 
-    iPhone 8 Plus (7FDC0186-E323-4DCC-A551-F1E8BE3DFF81) (Shutdown) 
-    iPhone 11 (5F553FBA-D19E-40F3-993C-444BB7AD8614) (Shutdown) 
-    iPhone 11 Pro (DAB5082C-4D8B-41AD-9C17-4B70D627B929) (Shutdown) 
-    iPhone 11 Pro Max (9EB86A56-B8A9-4EFB-83DD-CA545B03E380) (Shutdown) 
-    iPad Pro (9.7-inch) (CFADC040-4C11-45F6-A993-7C1547F0BF96) (Shutdown) 
-    iPad Pro (11-inch) (B3A6DA7F-F69F-4014-B858-C0231AEB8EA6) (Shutdown) 
-    iPad Pro (12.9-inch) (3rd generation) (B02BFD3E-8952-4785-9533-BBD96F8E303E) (Shutdown) 
-    iPad Air (3rd generation) (0CB42FD9-79CF-4B88-9DB4-348B2FB6FD1A) (Shutdown) 
 -- iOS 13.2 --
     iPhone 8 (7AE647E5-603E-4FB4-B420-D5C3F18E6BF9) (Shutdown) 
     iPhone 8 Plus (D52FCB1A-7C77-4A93-8B90-C214E810C7F3) (Shutdown) 
@@ -730,11 +1046,6 @@ watchOS 6.1 (6.1 - 17S83) - com.apple.CoreSimulator.SimRuntime.watchOS-6-1
     Apple Watch Series 3 - 42mm (503C2038-DD8D-406C-9DBB-72A00AFDEE2F) (Shutdown) 
     Apple Watch Series 4 - 40mm (08FEC067-9872-4D78-8C2A-2A8B6B710D03) (Shutdown) 
     Apple Watch Series 4 - 44mm (23DB7D1F-C1BD-4493-8144-F816A92F339E) (Shutdown) 
--- watchOS 6.0 --
-    Apple Watch Series 4 - 40mm (92E7A712-5892-4B48-8703-0C5E7B1FA998) (Shutdown) 
-    Apple Watch Series 4 - 44mm (8FD07916-D8DB-4653-AF98-C70D727C2969) (Shutdown) 
-    Apple Watch Series 5 - 40mm (BC7AA0B1-3FB6-4E3D-8E09-F039E67F6063) (Shutdown) 
-    Apple Watch Series 5 - 44mm (5D86025B-896E-42FF-94E6-12FA6FBE20B1) (Shutdown) 
 -- watchOS 6.1 --
     Apple Watch Series 4 - 40mm (3CA4F728-BC02-4800-B8FA-ADCB545EB117) (Shutdown) 
     Apple Watch Series 4 - 44mm (9A2CA57F-6E8E-4B1F-A8AD-CD34A0486EF7) (Shutdown) 
@@ -767,18 +1078,18 @@ Software:
       Kernel Version: Darwin 18.7.0
       Boot Volume: Untitled
       Boot Mode: Normal
-      Computer Name: stg-xcode-11-2-191128163600-xyj4tiNtt8G86dunZg3JmX
+      Computer Name: prd-std-g-xcode-11-2-191204105418-9hUBzxUuXrVGdkP5zNwQN3
       User Name: vagrant (vagrant)
       Secure Virtual Memory: Enabled
       System Integrity Protection: Disabled
-      Time since boot: 6 minutes
+      Time since boot: 3 minutes
 
 
 ========================================
 
 
 === System infos =======================
-* Free disk space: /dev/disk1s1  200Gi  169Gi   30Gi    86% 4239930 9223372036850535877    0%   /
+* Free disk space: /dev/disk1s1  200Gi  162Gi   37Gi    82% 4695906 9223372036850079901    0%   /
 ========================================
 
 --- Android

--- a/system_reports/osx-xcode-11.3.x.log
+++ b/system_reports/osx-xcode-11.3.x.log
@@ -33,9 +33,9 @@ OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.232-b09, mixed mode)
 * tar: bsdtar 2.8.3 - libarchive 2.8.3
 * tree: tree v1.8.0 (c) 1996 - 2018 by Steve Baker, Thomas Moore, Francesc Rocher, Florian Sesser, Kyosuke Tokoro 
 
-* brew: Homebrew 2.2.0
-Homebrew/homebrew-core (git revision c2ba; last commit 2019-11-27)
-Homebrew/homebrew-cask (git revision 60b11; last commit 2019-11-28)
+* brew: Homebrew 2.1.16
+Homebrew/homebrew-core (git revision 24ba; last commit 2019-11-22)
+Homebrew/homebrew-cask (git revision 27540f; last commit 2019-11-22)
 ./system_report.sh: line 58: xctool: command not found
 * xctool: 
 * Ansible: ansible 2.9.1
@@ -64,6 +64,334 @@ Error: No previously deleted formula found.
 * stepman: 0.11.11
 * envman: 2.2.9
 * cmd-bridge: 0.9.5
+========================================
+
+
+=== Brew list versions ==================
+ansible 2.9.1
+ant 1.10.7
+autoconf 2.69
+carthage 0.34.0
+coreutils 8.31
+flow 0.112.0
+freetype 2.10.1
+gdbm 1.18.1
+gettext 0.20.1
+ghostscript 9.50
+git 2.24.0_1
+git-lfs 2.8.0
+glib 2.62.3
+go 1.13.4
+gradle 6.0.1
+icu4c 64.2
+ilmbase 2.3.0
+imagemagick 7.0.9-5
+jenv 0.5.2
+jpeg 9c
+libde265 1.0.3
+libffi 3.2.1
+libheif 1.6.0
+libidn2 2.2.0_1
+libomp 9.0.0
+libpng 1.6.37
+libtiff 4.1.0
+libtool 2.4.6_1
+libunistring 0.9.10
+libyaml 0.2.2
+little-cms2 2.9
+maven 3.6.2
+mercurial 5.2_1
+node 13.1.0
+node@10 10.17.0
+openexr 2.3.0
+openjpeg 2.3.1
+openssl@1.1 1.1.1d
+pcre 8.43
+pcre2 10.33
+pkg-config 0.29.2
+python 3.7.5
+rbenv 1.1.2
+readline 8.0.1
+ruby-build 20191111
+screen 4.7.0
+shared-mime-info 1.15
+sqlite 3.30.1
+tree 1.8.0
+watchman 4.9.0_3
+webp 1.0.3
+wget 1.20.3_1
+x265 3.2.1
+xz 5.2.4
+yarn 1.19.1
+========================================
+
+
+=== Brew deps tree ==================
+ansible
+├── libyaml
+├── openssl@1.1
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+ant
+
+autoconf
+
+carthage
+
+coreutils
+
+flow
+
+freetype
+└── libpng
+
+gdbm
+
+gettext
+
+ghostscript
+└── libtiff
+    └── jpeg
+
+git
+├── gettext
+└── pcre2
+
+git-lfs
+
+glib
+├── gettext
+├── libffi
+├── pcre
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+go
+
+gradle
+
+icu4c
+
+ilmbase
+
+imagemagick
+├── freetype
+│   └── libpng
+├── jpeg
+├── libheif
+│   ├── jpeg
+│   ├── libde265
+│   ├── libpng
+│   ├── shared-mime-info
+│   │   ├── gettext
+│   │   └── glib
+│   │       ├── gettext
+│   │       ├── libffi
+│   │       ├── pcre
+│   │       └── python
+│   │           ├── gdbm
+│   │           ├── openssl@1.1
+│   │           ├── readline
+│   │           ├── sqlite
+│   │           │   └── readline
+│   │           └── xz
+│   └── x265
+├── libomp
+├── libpng
+├── libtiff
+│   └── jpeg
+├── libtool
+├── little-cms2
+│   ├── jpeg
+│   └── libtiff
+│       └── jpeg
+├── openexr
+│   └── ilmbase
+├── openjpeg
+│   ├── libpng
+│   ├── libtiff
+│   │   └── jpeg
+│   └── little-cms2
+│       ├── jpeg
+│       └── libtiff
+│           └── jpeg
+├── webp
+│   ├── jpeg
+│   ├── libpng
+│   └── libtiff
+│       └── jpeg
+└── xz
+
+jenv
+
+jpeg
+
+libde265
+
+libffi
+
+libheif
+├── jpeg
+├── libde265
+├── libpng
+├── shared-mime-info
+│   ├── gettext
+│   └── glib
+│       ├── gettext
+│       ├── libffi
+│       ├── pcre
+│       └── python
+│           ├── gdbm
+│           ├── openssl@1.1
+│           ├── readline
+│           ├── sqlite
+│           │   └── readline
+│           └── xz
+└── x265
+
+libidn2
+├── gettext
+└── libunistring
+
+libomp
+
+libpng
+
+libtiff
+└── jpeg
+
+libtool
+
+libunistring
+
+libyaml
+
+little-cms2
+├── jpeg
+└── libtiff
+    └── jpeg
+
+maven
+
+mercurial
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+node
+└── icu4c
+
+node@10
+└── icu4c
+
+openexr
+└── ilmbase
+
+openjpeg
+├── libpng
+├── libtiff
+│   └── jpeg
+└── little-cms2
+    ├── jpeg
+    └── libtiff
+        └── jpeg
+
+openssl@1.1
+
+pcre
+
+pcre2
+
+pkg-config
+
+python
+├── gdbm
+├── openssl@1.1
+├── readline
+├── sqlite
+│   └── readline
+└── xz
+
+rbenv
+└── ruby-build
+    ├── autoconf
+    ├── pkg-config
+    └── readline
+
+readline
+
+ruby-build
+├── autoconf
+├── pkg-config
+└── readline
+
+screen
+
+shared-mime-info
+├── gettext
+└── glib
+    ├── gettext
+    ├── libffi
+    ├── pcre
+    └── python
+        ├── gdbm
+        ├── openssl@1.1
+        ├── readline
+        ├── sqlite
+        │   └── readline
+        └── xz
+
+sqlite
+└── readline
+
+tree
+
+watchman
+├── openssl@1.1
+├── pcre
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+webp
+├── jpeg
+├── libpng
+└── libtiff
+    └── jpeg
+
+wget
+├── libidn2
+│   ├── gettext
+│   └── libunistring
+└── openssl@1.1
+
+x265
+
+xz
+
+yarn
+└── node
+    └── icu4c
+
 ========================================
 
 
@@ -745,18 +1073,18 @@ Software:
       Kernel Version: Darwin 18.7.0
       Boot Volume: Untitled
       Boot Mode: Normal
-      Computer Name: stg-xcode-11-3-191128170254-PoAfKHTGhVv4uaP6MDHMrK
+      Computer Name: prd-std-y-xcode-11-3-191204104227-J2SmuzXyErAvH6pAWfdoQ9
       User Name: vagrant (vagrant)
       Secure Virtual Memory: Enabled
       System Integrity Protection: Disabled
-      Time since boot: 5 minutes
+      Time since boot: 15 minutes
 
 
 ========================================
 
 
 === System infos =======================
-* Free disk space: /dev/disk1s1  200Gi  158Gi   42Gi    80% 4928332 9223372036849847475    0%   /
+* Free disk space: /dev/disk1s1  200Gi  158Gi   42Gi    80% 4925190 9223372036849850617    0%   /
 ========================================
 
 --- Android

--- a/system_reports/osx-xcode-8.3.x.log
+++ b/system_reports/osx-xcode-8.3.x.log
@@ -33,9 +33,9 @@ OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.232-b09, mixed mode)
 * tar: bsdtar 2.8.3 - libarchive 2.8.3
 * tree: tree v1.7.0 (c) 1996 - 2014 by Steve Baker, Thomas Moore, Francesc Rocher, Florian Sesser, Kyosuke Tokoro 
 
-* brew: Homebrew 2.2.0
-Homebrew/homebrew-core (git revision c2ba6; last commit 2019-11-27)
-Homebrew/homebrew-cask (git revision 60b1; last commit 2019-11-28)
+* brew: Homebrew 2.1.16
+Homebrew/homebrew-core (git revision 079ce5; last commit 2019-11-21)
+Homebrew/homebrew-cask (git revision 98a4; last commit 2019-11-21)
 ./system_report.sh: line 58: xctool: command not found
 * xctool: 
 * Ansible: ansible 2.3.1.0
@@ -61,6 +61,229 @@ Error: No previously deleted formula found.
 * stepman: 0.11.11
 * envman: 2.2.9
 * cmd-bridge: 0.9.5
+========================================
+
+
+=== Brew list versions ==================
+ansible 2.3.1.0
+ant 1.10.7
+autoconf 2.69
+automake 1.16.1_1
+carthage 0.23.0
+coreutils 8.27
+flow 0.47.0
+freetype 2.8
+gdbm 1.13
+ghostscript 9.21_1
+git 2.13.1
+git-lfs 2.1.1
+go 1.8.3
+gradle 6.0.1
+icu4c 58.2
+imagemagick 7.0.5-10
+jenv 0.5.2
+jpeg 8d
+libpng 1.6.29
+libtiff 4.0.8
+libtool 2.4.6_1
+libyaml 0.1.7
+little-cms2 2.8
+maven 3.6.2
+mercurial 4.2.1
+node 8.0.0_1
+openssl 1.0.2l
+openssl@1.1 1.1.0f
+pcre 8.40
+python 2.7.13
+readline 7.0.3_1
+ruby 2.4.1_1
+screen 4.7.0
+sqlite 3.19.2
+tree 1.7.0
+watchman 4.7.0
+wget 1.19.1_1
+xz 5.2.3
+yarn 0.24.6
+========================================
+
+
+=== Brew deps tree ==================
+ansible
+├── libyaml
+├── openssl@1.1
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+ant
+
+autoconf
+
+automake
+└── autoconf
+
+carthage
+
+coreutils
+
+flow
+
+freetype
+└── libpng
+
+gdbm
+
+ghostscript
+└── libtiff
+    └── jpeg
+
+git
+├── gettext
+└── pcre2
+
+git-lfs
+
+go
+
+gradle
+
+icu4c
+
+imagemagick
+├── freetype
+│   └── libpng
+├── jpeg
+├── libheif
+│   ├── jpeg
+│   ├── libde265
+│   ├── libpng
+│   ├── shared-mime-info
+│   │   ├── gettext
+│   │   └── glib
+│   │       ├── gettext
+│   │       ├── libffi
+│   │       ├── pcre
+│   │       └── python
+│   │           ├── gdbm
+│   │           ├── openssl@1.1
+│   │           ├── readline
+│   │           ├── sqlite
+│   │           │   └── readline
+│   │           └── xz
+│   └── x265
+├── libomp
+├── libpng
+├── libtiff
+│   └── jpeg
+├── libtool
+├── little-cms2
+│   ├── jpeg
+│   └── libtiff
+│       └── jpeg
+├── openexr
+│   └── ilmbase
+├── openjpeg
+│   ├── libpng
+│   ├── libtiff
+│   │   └── jpeg
+│   └── little-cms2
+│       ├── jpeg
+│       └── libtiff
+│           └── jpeg
+├── webp
+│   ├── jpeg
+│   ├── libpng
+│   └── libtiff
+│       └── jpeg
+└── xz
+
+jenv
+
+jpeg
+
+libpng
+
+libtiff
+└── jpeg
+
+libtool
+
+libyaml
+
+little-cms2
+├── jpeg
+└── libtiff
+    └── jpeg
+
+maven
+
+mercurial
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+node
+└── icu4c
+
+openssl
+
+openssl@1.1
+
+pcre
+
+python
+├── gdbm
+├── openssl@1.1
+├── readline
+├── sqlite
+│   └── readline
+└── xz
+
+readline
+
+ruby
+├── libyaml
+├── openssl@1.1
+└── readline
+
+screen
+
+sqlite
+└── readline
+
+tree
+
+watchman
+├── openssl@1.1
+├── pcre
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+wget
+├── libidn2
+│   ├── gettext
+│   └── libunistring
+└── openssl@1.1
+
+xz
+
+yarn
+└── node
+    └── icu4c
+
 ========================================
 
 
@@ -475,10 +698,10 @@ watchOS 3.2 (3.2 - 14V243) (com.apple.CoreSimulator.SimRuntime.watchOS-3-2)
     Apple Watch - 38mm (BF347887-4520-46A0-A62C-D3A3E2EF4550) (Shutdown)
     Apple Watch - 42mm (C679BEA9-1810-407E-8B6C-A34CD11A7B6C) (Shutdown)
 -- watchOS 3.1 --
-    Apple Watch - 38mm (67E757D9-DE64-4A78-BF36-A20AAA29607A) (Shutdown)
-    Apple Watch - 42mm (1FFB067A-F3B0-497C-9CAA-5DB06AF2CFBB) (Shutdown)
-    Apple Watch Series 2 - 38mm (2C115F28-0F50-49C6-8BA6-0AB708EFD55F) (Shutdown)
-    Apple Watch Series 2 - 42mm (031AC0A6-37DE-4326-AE94-95DFF89B58A8) (Shutdown)
+    Apple Watch - 38mm (82257F66-CF0B-43EA-8192-80DAA87591C5) (Shutdown)
+    Apple Watch - 42mm (43EA2804-615C-4288-8810-B2DF27B8F754) (Shutdown)
+    Apple Watch Series 2 - 38mm (AF6DC259-D996-4B82-8D3B-8EE47BB641AD) (Shutdown)
+    Apple Watch Series 2 - 42mm (50185754-D380-42E9-B1CD-5A37F33F57ED) (Shutdown)
 -- watchOS 3.2 --
     Apple Watch - 38mm (AB0792A9-3712-4F62-BBE8-D1FBAAF40854) (Shutdown)
     Apple Watch - 42mm (35DB9537-433D-45E5-AE16-31D754559A4C) (Shutdown)
@@ -517,18 +740,18 @@ Software:
       Kernel Version: Darwin 16.7.0
       Boot Volume: Macintosh HD
       Boot Mode: Normal
-      Computer Name: stg-xcode-8-3-191128162417-5bcAxfynkHycEwHmCfqntW
+      Computer Name: prd-std-b-xcode-8-3-191204095540-mHVfc3H9JVSNAdyKPPFuYD
       User Name: vagrant (vagrant)
       Secure Virtual Memory: Enabled
       System Integrity Protection: Disabled
-      Time since boot: 28 minutes
+      Time since boot: 1:01
 
 
 ========================================
 
 
 === System infos =======================
-* Free disk space: /dev/disk0s2  199Gi  101Gi   98Gi    51% 3205162 4291762117    0%   /
+* Free disk space: /dev/disk0s2  199Gi  101Gi   98Gi    51% 3201302 4291765977    0%   /
 ========================================
 
 --- Android

--- a/system_reports/osx-xcode-9.4.x.log
+++ b/system_reports/osx-xcode-9.4.x.log
@@ -33,9 +33,9 @@ OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.232-b09, mixed mode)
 * tar: bsdtar 2.8.3 - libarchive 2.8.3
 * tree: tree v1.7.0 (c) 1996 - 2014 by Steve Baker, Thomas Moore, Francesc Rocher, Florian Sesser, Kyosuke Tokoro 
 
-* brew: Homebrew 2.2.0
-Homebrew/homebrew-core (git revision c2ba6; last commit 2019-11-27)
-Homebrew/homebrew-cask (git revision 60b11; last commit 2019-11-28)
+* brew: Homebrew 2.1.16
+Homebrew/homebrew-core (git revision 079ce5; last commit 2019-11-21)
+Homebrew/homebrew-cask (git revision b6142; last commit 2019-11-21)
 ./system_report.sh: line 58: xctool: command not found
 * xctool: 
 * Ansible: ansible 2.5.4
@@ -64,6 +64,229 @@ Error: No previously deleted formula found.
 * stepman: 0.11.11
 * envman: 2.2.9
 * cmd-bridge: 0.9.5
+========================================
+
+
+=== Brew list versions ==================
+ansible 2.5.4
+ant 1.10.7
+carthage 0.29.0
+coreutils 8.29
+flow 0.74.0
+freetype 2.9.1
+gdbm 1.14.1_1
+gettext 0.19.8.1
+ghostscript 9.23
+git 2.17.1
+git-lfs 2.4.2
+go 1.10.3
+gradle 6.0.1
+icu4c 61.1
+imagemagick 7.0.8-0
+jenv 0.5.2
+jpeg 9c
+libidn2 2.0.5
+libpng 1.6.34
+libtiff 4.0.9_3
+libtool 2.4.6_1
+libunistring 0.9.10
+libyaml 0.1.7
+little-cms2 2.9
+maven 3.6.2
+mercurial 4.6.1
+node 10.4.1
+openssl 1.0.2o_1
+pcre 8.42
+python@2 2.7.15
+readline 7.0.3_1
+ruby 2.5.1
+screen 4.6.2
+sqlite 3.24.0
+tree 1.7.0
+watchman 4.9.0
+wget 1.19.5
+xz 5.2.4
+yarn 1.7.0
+========================================
+
+
+=== Brew deps tree ==================
+ansible
+├── libyaml
+├── openssl@1.1
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+ant
+
+carthage
+
+coreutils
+
+flow
+
+freetype
+└── libpng
+
+gdbm
+
+gettext
+
+ghostscript
+└── libtiff
+    └── jpeg
+
+git
+├── gettext
+└── pcre2
+
+git-lfs
+
+go
+
+gradle
+
+icu4c
+
+imagemagick
+├── freetype
+│   └── libpng
+├── jpeg
+├── libheif
+│   ├── jpeg
+│   ├── libde265
+│   ├── libpng
+│   ├── shared-mime-info
+│   │   ├── gettext
+│   │   └── glib
+│   │       ├── gettext
+│   │       ├── libffi
+│   │       ├── pcre
+│   │       └── python
+│   │           ├── gdbm
+│   │           ├── openssl@1.1
+│   │           ├── readline
+│   │           ├── sqlite
+│   │           │   └── readline
+│   │           └── xz
+│   └── x265
+├── libomp
+├── libpng
+├── libtiff
+│   └── jpeg
+├── libtool
+├── little-cms2
+│   ├── jpeg
+│   └── libtiff
+│       └── jpeg
+├── openexr
+│   └── ilmbase
+├── openjpeg
+│   ├── libpng
+│   ├── libtiff
+│   │   └── jpeg
+│   └── little-cms2
+│       ├── jpeg
+│       └── libtiff
+│           └── jpeg
+├── webp
+│   ├── jpeg
+│   ├── libpng
+│   └── libtiff
+│       └── jpeg
+└── xz
+
+jenv
+
+jpeg
+
+libidn2
+├── gettext
+└── libunistring
+
+libpng
+
+libtiff
+└── jpeg
+
+libtool
+
+libunistring
+
+libyaml
+
+little-cms2
+├── jpeg
+└── libtiff
+    └── jpeg
+
+maven
+
+mercurial
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+node
+└── icu4c
+
+openssl
+
+pcre
+
+python@2
+├── gdbm
+├── openssl@1.1
+├── readline
+└── sqlite
+    └── readline
+
+readline
+
+ruby
+├── libyaml
+├── openssl@1.1
+└── readline
+
+screen
+
+sqlite
+└── readline
+
+tree
+
+watchman
+├── openssl@1.1
+├── pcre
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+wget
+├── libidn2
+│   ├── gettext
+│   └── libunistring
+└── openssl@1.1
+
+xz
+
+yarn
+└── node
+    └── icu4c
+
 ========================================
 
 
@@ -668,18 +891,18 @@ Software:
       Kernel Version: Darwin 17.6.0
       Boot Volume: Macintosh HD
       Boot Mode: Normal
-      Computer Name: stg-xcode-9-4-191128162735-LR2PUSz5DNNo6VACwEwUFY
+      Computer Name: prd-std-b-xcode-9-4-191204095345-YamNJ7vksGr7UYisgfoKFP
       User Name: vagrant (vagrant)
       Secure Virtual Memory: Enabled
       System Integrity Protection: Disabled
-      Time since boot: 24 minutes
+      Time since boot: 1:03
 
 
 ========================================
 
 
 === System infos =======================
-* Free disk space: /dev/disk0s2  199Gi  141Gi   58Gi    71% 4175790 4290791489    0%   /
+* Free disk space: /dev/disk0s2  199Gi  141Gi   58Gi    71% 4171793 4290795486    0%   /
 ========================================
 
 --- Android

--- a/system_reports/osx-xcode-edge.log
+++ b/system_reports/osx-xcode-edge.log
@@ -33,9 +33,9 @@ OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.222-b10, mixed mode)
 * tar: bsdtar 2.8.3 - libarchive 2.8.3
 * tree: tree v1.8.0 (c) 1996 - 2018 by Steve Baker, Thomas Moore, Francesc Rocher, Florian Sesser, Kyosuke Tokoro 
 
-* brew: Homebrew 2.2.0
-Homebrew/homebrew-core (git revision 808d3; last commit 2019-11-28)
-Homebrew/homebrew-cask (git revision e1f2f4; last commit 2019-11-28)
+* brew: Homebrew 2.1.16
+Homebrew/homebrew-core (git revision 079c; last commit 2019-11-21)
+Homebrew/homebrew-cask (git revision 3dd39d; last commit 2019-11-21)
 ./system_report.sh: line 58: xctool: command not found
 * xctool: 
 * Ansible: ansible 2.8.5
@@ -64,6 +64,342 @@ Error: No previously deleted formula found.
 * stepman: 0.11.11
 * envman: 2.2.9
 * cmd-bridge: 0.9.5
+========================================
+
+
+=== Brew list versions ==================
+ansible 2.8.5
+ant 1.10.7
+autoconf 2.69
+carthage 0.33.0
+coreutils 8.31
+flow 0.109.0
+freetype 2.10.1
+gdbm 1.18.1
+gettext 0.20.1
+ghostscript 9.27_1
+git 2.23.0_1
+git-lfs 2.8.0
+glib 2.62.0_1
+go 1.13.1
+gradle 5.6.2
+icu4c 64.2
+ilmbase 2.3.0
+imagemagick 7.0.8-66
+jenv 0.5.2
+jpeg 9c
+libde265 1.0.3
+libffi 3.2.1
+libheif 1.5.1
+libidn2 2.2.0_1
+libomp 9.0.0
+libpng 1.6.37
+libtiff 4.0.10_1
+libtool 2.4.6_1
+libunistring 0.9.10
+libyaml 0.2.2
+little-cms2 2.9
+maven 3.6.2
+mercurial 5.1.1_2
+node 12.11.1
+node@10 10.16.3
+openexr 2.3.0
+openjpeg 2.3.1
+openssl@1.1 1.1.1d
+pcre 8.43
+pcre2 10.33
+pkg-config 0.29.2
+python 3.7.4_1
+python@2 2.7.16_1
+rbenv 1.1.2
+readline 8.0.1
+ruby-build 20191004
+screen 4.6.2
+shared-mime-info 1.14
+sqlite 3.29.0
+tree 1.8.0
+watchman 4.9.0_3
+webp 1.0.3
+wget 1.20.3_1
+x265 3.1.2
+xz 5.2.4
+yarn 1.19.0
+========================================
+
+
+=== Brew deps tree ==================
+ansible
+├── libyaml
+├── openssl@1.1
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+ant
+
+autoconf
+
+carthage
+
+coreutils
+
+flow
+
+freetype
+└── libpng
+
+gdbm
+
+gettext
+
+ghostscript
+└── libtiff
+    └── jpeg
+
+git
+├── gettext
+└── pcre2
+
+git-lfs
+
+glib
+├── gettext
+├── libffi
+├── pcre
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+go
+
+gradle
+
+icu4c
+
+ilmbase
+
+imagemagick
+├── freetype
+│   └── libpng
+├── jpeg
+├── libheif
+│   ├── jpeg
+│   ├── libde265
+│   ├── libpng
+│   ├── shared-mime-info
+│   │   ├── gettext
+│   │   └── glib
+│   │       ├── gettext
+│   │       ├── libffi
+│   │       ├── pcre
+│   │       └── python
+│   │           ├── gdbm
+│   │           ├── openssl@1.1
+│   │           ├── readline
+│   │           ├── sqlite
+│   │           │   └── readline
+│   │           └── xz
+│   └── x265
+├── libomp
+├── libpng
+├── libtiff
+│   └── jpeg
+├── libtool
+├── little-cms2
+│   ├── jpeg
+│   └── libtiff
+│       └── jpeg
+├── openexr
+│   └── ilmbase
+├── openjpeg
+│   ├── libpng
+│   ├── libtiff
+│   │   └── jpeg
+│   └── little-cms2
+│       ├── jpeg
+│       └── libtiff
+│           └── jpeg
+├── webp
+│   ├── jpeg
+│   ├── libpng
+│   └── libtiff
+│       └── jpeg
+└── xz
+
+jenv
+
+jpeg
+
+libde265
+
+libffi
+
+libheif
+├── jpeg
+├── libde265
+├── libpng
+├── shared-mime-info
+│   ├── gettext
+│   └── glib
+│       ├── gettext
+│       ├── libffi
+│       ├── pcre
+│       └── python
+│           ├── gdbm
+│           ├── openssl@1.1
+│           ├── readline
+│           ├── sqlite
+│           │   └── readline
+│           └── xz
+└── x265
+
+libidn2
+├── gettext
+└── libunistring
+
+libomp
+
+libpng
+
+libtiff
+└── jpeg
+
+libtool
+
+libunistring
+
+libyaml
+
+little-cms2
+├── jpeg
+└── libtiff
+    └── jpeg
+
+maven
+
+mercurial
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+node
+└── icu4c
+
+node@10
+└── icu4c
+
+openexr
+└── ilmbase
+
+openjpeg
+├── libpng
+├── libtiff
+│   └── jpeg
+└── little-cms2
+    ├── jpeg
+    └── libtiff
+        └── jpeg
+
+openssl@1.1
+
+pcre
+
+pcre2
+
+pkg-config
+
+python
+├── gdbm
+├── openssl@1.1
+├── readline
+├── sqlite
+│   └── readline
+└── xz
+
+python@2
+├── gdbm
+├── openssl@1.1
+├── readline
+└── sqlite
+    └── readline
+
+rbenv
+└── ruby-build
+    ├── autoconf
+    ├── pkg-config
+    └── readline
+
+readline
+
+ruby-build
+├── autoconf
+├── pkg-config
+└── readline
+
+screen
+
+shared-mime-info
+├── gettext
+└── glib
+    ├── gettext
+    ├── libffi
+    ├── pcre
+    └── python
+        ├── gdbm
+        ├── openssl@1.1
+        ├── readline
+        ├── sqlite
+        │   └── readline
+        └── xz
+
+sqlite
+└── readline
+
+tree
+
+watchman
+├── openssl@1.1
+├── pcre
+└── python
+    ├── gdbm
+    ├── openssl@1.1
+    ├── readline
+    ├── sqlite
+    │   └── readline
+    └── xz
+
+webp
+├── jpeg
+├── libpng
+└── libtiff
+    └── jpeg
+
+wget
+├── libidn2
+│   ├── gettext
+│   └── libunistring
+└── openssl@1.1
+
+x265
+
+xz
+
+yarn
+└── node
+    └── icu4c
+
 ========================================
 
 
@@ -131,12 +467,12 @@ e2mmap (default: 0.1.0)
 emoji_regex (1.0.1)
 escape (0.0.4)
 etc (default: 1.0.1)
-excon (0.69.1)
-faraday (0.17.1)
+excon (0.68.0)
+faraday (0.17.0)
 faraday-cookie_jar (0.0.6)
 faraday_middleware (0.13.1)
 fastimage (2.1.7)
-fastlane (2.137.0)
+fastlane (2.136.0)
 fcntl (default: 1.0.0)
 fiddle (default: 1.0.0)
 fileutils (default: 1.1.0)
@@ -742,18 +1078,18 @@ Software:
       Kernel Version: Darwin 18.7.0
       Boot Volume: Untitled
       Boot Mode: Normal
-      Computer Name: stg-xcode-edge-191128163600-ffUQGroLtkXhg6b78ARfic
+      Computer Name: prd-std-r-xcode-edge-191203165745-SirhjKBk6gi8UFzCNtj3Pd
       User Name: vagrant (vagrant)
       Secure Virtual Memory: Enabled
       System Integrity Protection: Disabled
-      Time since boot: 5 minutes
+      Time since boot: 17:59
 
 
 ========================================
 
 
 === System infos =======================
-* Free disk space: /dev/disk1s1  200Gi  162Gi   38Gi    82% 4679257 9223372036850096550    0%   /
+* Free disk space: /dev/disk1s1  200Gi  161Gi   38Gi    82% 4674795 9223372036850101012    0%   /
 ========================================
 
 --- Android


### PR DESCRIPTION
Using the recently merged system report update to include `brew list --versions` and `brew deps --tree --installed` in the report (https://github.com/bitrise-io/osx-box-bootstrap/pull/213) we re-run the system reports on the current stacks to get a baseline before the next weekly stack update.