### PR TITLE
Deprecate old system reports

### DIFF
--- a/system_reports/LINUX/linux-docker-android-20.04.log
+++ b/system_reports/LINUX/linux-docker-android-20.04.log
@@ -1,3 +1,11 @@
+👋 Heads up:
+The system reports have moved to  👉 https://stacks.bitrise.io 👈
+This file is no longer updated.
+
+
+
+
+
  (i) Ignore Errors: disabled
 
 #

--- a/system_reports/MACOS/M1/osx-xcode-14.0.x-ventura.log
+++ b/system_reports/MACOS/M1/osx-xcode-14.0.x-ventura.log
@@ -1,3 +1,11 @@
+👋 Heads up:
+The system reports have moved to  👉 https://stacks.bitrise.io 👈
+This file is no longer updated.
+
+
+
+
+
  (i) Ignore Errors: disabled
 
 

--- a/system_reports/MACOS/M1/osx-xcode-14.0.x.log
+++ b/system_reports/MACOS/M1/osx-xcode-14.0.x.log
@@ -1,3 +1,11 @@
+👋 Heads up:
+The system reports have moved to  👉 https://stacks.bitrise.io 👈
+This file is no longer updated.
+
+
+
+
+
  (i) Ignore Errors: disabled
 
 

--- a/system_reports/MACOS/M1/osx-xcode-14.1.x-ventura.log
+++ b/system_reports/MACOS/M1/osx-xcode-14.1.x-ventura.log
@@ -1,3 +1,11 @@
+👋 Heads up:
+The system reports have moved to  👉 https://stacks.bitrise.io 👈
+This file is no longer updated.
+
+
+
+
+
  (i) Ignore Errors: disabled
 
 

--- a/system_reports/MACOS/M1/osx-xcode-14.1.x.log
+++ b/system_reports/MACOS/M1/osx-xcode-14.1.x.log
@@ -1,3 +1,11 @@
+👋 Heads up:
+The system reports have moved to  👉 https://stacks.bitrise.io 👈
+This file is no longer updated.
+
+
+
+
+
  (i) Ignore Errors: disabled
 
 

--- a/system_reports/MACOS/M1/osx-xcode-14.2.x-ventura.log
+++ b/system_reports/MACOS/M1/osx-xcode-14.2.x-ventura.log
@@ -1,3 +1,11 @@
+👋 Heads up:
+The system reports have moved to  👉 https://stacks.bitrise.io 👈
+This file is no longer updated.
+
+
+
+
+
  (i) Ignore Errors: disabled
 
 

--- a/system_reports/MACOS/M1/osx-xcode-14.3.x-edge.log
+++ b/system_reports/MACOS/M1/osx-xcode-14.3.x-edge.log
@@ -1,3 +1,11 @@
+👋 Heads up:
+The system reports have moved to  👉 https://stacks.bitrise.io 👈
+This file is no longer updated.
+
+
+
+
+
  (i) Ignore Errors: disabled
 
 

--- a/system_reports/MACOS/M1/osx-xcode-14.3.x-ventura.log
+++ b/system_reports/MACOS/M1/osx-xcode-14.3.x-ventura.log
@@ -1,3 +1,10 @@
+👋 Heads up:
+The system reports have moved to  👉 https://stacks.bitrise.io 👈
+This file is no longer updated.
+
+
+
+
  (i) Ignore Errors: disabled
 
 

--- a/system_reports/MACOS/M1/osx-xcode-15.0.x-edge.log
+++ b/system_reports/MACOS/M1/osx-xcode-15.0.x-edge.log
@@ -1,3 +1,10 @@
+👋 Heads up:
+The system reports have moved to  👉 https://stacks.bitrise.io 👈
+This file is no longer updated.
+
+
+
+
  (i) Ignore Errors: disabled
 
 

--- a/system_reports/README.md
+++ b/system_reports/README.md
@@ -1,0 +1,5 @@
+# System reports
+
+👋 Heads up:
+The system reports have moved to  👉 https://stacks.bitrise.io 👈
+These files are no longer updated.


### PR DESCRIPTION
Instead of deleting the reports in this repo, this PR adds a note with a link to the new reports.

Only the actively updated stack reports got a note as we don't have new system reports for the frozen stacks.